### PR TITLE
Exact simplicial homology: Betti numbers, generators, and a Betti-derived harmonic count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,10 @@ dependencies = [
  "mshio",
  "nalgebra",
  "nalgebra-sparse",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-rational 0.4.2",
+ "num-traits",
  "rayon",
  "tracing",
 ]

--- a/crates/formoniq/examples/hodge_laplace_source.rs
+++ b/crates/formoniq/examples/hodge_laplace_source.rs
@@ -19,7 +19,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   fs::create_dir_all(path).unwrap();
 
   let grade = 1;
-  let homology_dim = 0;
 
   for dim in 2_usize..=3 {
     println!("Solving Hodge-Laplace in {dim}d.");
@@ -107,7 +106,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         WhitneyComplex::new(&topology, &metric),
         source_data,
         grade,
-        homology_dim,
       );
 
       let conv_rate = |errors: &[f64], curr: f64| {

--- a/crates/formoniq/examples/hodge_laplace_sphere.rs
+++ b/crates/formoniq/examples/hodge_laplace_sphere.rs
@@ -35,7 +35,6 @@ fn main() {
   tracing_subscriber::fmt::init();
 
   let grade = 1;
-  let homology_dim = 0;
 
   // The unit sphere as a continuum. `sphere(2)` gives the hyperspherical
   // forward map with its closed-form nearest-point chart; the axis convention is
@@ -66,7 +65,6 @@ fn main() {
       WhitneyComplex::new(&topology, &metric),
       source,
       grade,
-      homology_dim,
     );
 
     let solution = solution_exact.pullback_through(&topology, &coords, &sphere);

--- a/crates/formoniq/src/problems/hodge_laplace.rs
+++ b/crates/formoniq/src/problems/hodge_laplace.rs
@@ -17,9 +17,8 @@ pub fn solve_hodge_laplace_source(
   whitney: WhitneyComplex,
   source_galvec: GalVec,
   grade: ExteriorGrade,
-  homology_dim: usize,
 ) -> (Cochain, Cochain, Cochain) {
-  let harmonics = solve_hodge_laplace_harmonics(whitney, grade, homology_dim);
+  let harmonics = solve_hodge_laplace_harmonics(whitney, grade);
 
   let galmats = MixedGalmats::compute(whitney, grade);
 
@@ -72,11 +71,11 @@ pub fn solve_hodge_laplace_source(
   (sigma, u, p)
 }
 
-pub fn solve_hodge_laplace_harmonics(
-  whitney: WhitneyComplex,
-  grade: ExteriorGrade,
-  homology_dim: usize,
-) -> Matrix {
+pub fn solve_hodge_laplace_harmonics(whitney: WhitneyComplex, grade: ExteriorGrade) -> Matrix {
+  // The dimension of the harmonic space is the Betti number $b_k$ (Hodge
+  // theorem: $cal(H)^k tilde.equ H^k tilde.equ H_k$), an exact topological
+  // invariant of the complex — not a number the caller has to know.
+  let homology_dim = whitney.topology().betti_number(grade);
   if homology_dim == 0 {
     let nwhitneys = whitney.ndofs(grade);
     return Matrix::zeros(nwhitneys, 0);

--- a/crates/formoniq/tests/hodge_theory.rs
+++ b/crates/formoniq/tests/hodge_theory.rs
@@ -78,7 +78,7 @@ fn harmonics_are_cohomology_cube() {
       let mass = Matrix::from(&whitney.mass(k));
       let harmonic_dim = harmonic_space_dim(whitney.ndofs(k), dif, dif_prev, mass);
 
-      let betti = topology.homology_dim(k);
+      let betti = topology.betti_number(k);
       let expected = usize::from(k == 0);
       assert_eq!(betti, expected);
       assert_eq!(harmonic_dim, betti, "dim={dim} k={k}");
@@ -107,7 +107,7 @@ fn harmonics_are_cohomology_sphere() {
     let mass = Matrix::from(&whitney.mass(k));
     let harmonic_dim = harmonic_space_dim(whitney.ndofs(k), dif, dif_prev, mass);
 
-    assert_eq!(topology.homology_dim(k), expected);
+    assert_eq!(topology.betti_number(k), expected);
     assert_eq!(harmonic_dim, expected, "k={k}");
   }
 }
@@ -244,7 +244,7 @@ fn long_exact_sequence_of_the_pair_annulus() {
   // Absolute cohomology and harmonics.
   let mut betti_abs = Vec::new();
   for k in 0..=dim {
-    let betti = topology.homology_dim(k);
+    let betti = topology.betti_number(k);
     let dif = (k < dim).then(|| dense(&whitney.dif(k)));
     let dif_prev = (k > 0).then(|| dense(&whitney.dif(k - 1)));
     let mass = Matrix::from(&whitney.mass(k));
@@ -287,7 +287,7 @@ fn long_exact_sequence_of_the_pair_annulus() {
   // Boundary cohomology: two circles.
   let boundary = topology.boundary_complex().unwrap();
   let betti_bdry: Vec<_> = (0..=boundary.dim())
-    .map(|k| boundary.complex().homology_dim(k))
+    .map(|k| boundary.complex().betti_number(k))
     .collect();
   assert_eq!(betti_bdry, vec![2, 2]);
 

--- a/crates/manifold/Cargo.toml
+++ b/crates/manifold/Cargo.toml
@@ -10,6 +10,11 @@ common = { path = "../common" }
 nalgebra = "0.35.0"
 nalgebra-sparse = "0.12.0"
 
+num-bigint = "0.4.6"
+num-rational = "0.4.2"
+num-integer = "0.1.46"
+num-traits = "0.2.19"
+
 indexmap = "2.14.0"
 itertools = "0.15.0"
 tracing = "0.1.44"

--- a/crates/manifold/src/topology.rs
+++ b/crates/manifold/src/topology.rs
@@ -2,6 +2,7 @@ pub mod boundary;
 pub mod complex;
 pub mod data;
 pub mod handle;
+pub mod homology;
 pub mod simplex;
 pub mod skeleton;
 

--- a/crates/manifold/src/topology/boundary.rs
+++ b/crates/manifold/src/topology/boundary.rs
@@ -182,7 +182,7 @@ mod test {
           usize::from(k == 0 || k == dim - 1)
         };
         assert_eq!(
-          boundary.complex().homology_dim(k),
+          boundary.complex().betti_number(k),
           expected,
           "dim={dim} k={k}"
         );

--- a/crates/manifold/src/topology/complex.rs
+++ b/crates/manifold/src/topology/complex.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::Dim;
 
-use common::linalg::nalgebra::{CooMatrix, CooMatrixExt, Matrix};
+use common::linalg::nalgebra::{CooMatrix, CooMatrixExt};
 
 use itertools::Itertools;
 
@@ -169,35 +169,10 @@ impl Complex {
   ///
   /// The coboundary operator, which is the discrete exterior derivative
   /// on cochains. It is the transpose of the boundary operator.
+  ///
+  /// The Betti numbers of the complex are in [`homology`](super::homology).
   pub fn coboundary_operator(&self, dim: Dim) -> CooMatrix {
     self.boundary_operator(dim + 1).clone().transpose()
-  }
-
-  /// Dimension of the k-th homology group.
-  ///
-  /// k-th Betti number.
-  /// Number of k-dimensional holes in the manifold.
-  /// Computed using simplicial homology.
-  pub fn homology_dim(&self, dim: Dim) -> usize {
-    // TODO: use sparse matrix!
-    let boundary_this = Matrix::from(self.boundary_operator(dim));
-    let boundary_plus = Matrix::from(self.boundary_operator(dim + 1));
-
-    const RANK_TOL: f64 = 1e-12;
-
-    let dim_image = |op: &Matrix| -> usize {
-      if op.is_empty() {
-        0
-      } else {
-        op.rank(RANK_TOL)
-      }
-    };
-    let dim_kernel = |op: &Matrix| -> usize { op.ncols() - dim_image(op) };
-
-    let dim_cycles = dim_kernel(&boundary_this);
-    let dim_boundaries = dim_image(&boundary_plus);
-
-    dim_cycles - dim_boundaries
   }
 }
 
@@ -262,6 +237,7 @@ mod test {
   use crate::topology::simplex::{nsubsimplices, standard_boundary_operator, Simplex};
 
   use super::*;
+  use common::linalg::nalgebra::Matrix;
 
   /// Every skeleton is in canonical colexicographic order, and the vertices
   /// are contiguous and fully used. This is the ordering contract the file

--- a/crates/manifold/src/topology/homology.rs
+++ b/crates/manifold/src/topology/homology.rs
@@ -20,9 +20,20 @@
 //! mesh. The full torsion of $H_k (K; ZZ)$ is not recovered -- it is invisible to
 //! the de Rham / Hodge side of the library, which lives over $RR$ -- so only the
 //! free rank is returned.
+//!
+//! [`Complex::homology_generators`] goes further and returns representative
+//! cycles: a [`Chain`] for each Betti number, whose classes form a basis of the
+//! free part of $H_k$. That step needs a basis of $ker diff_k$ modulo
+//! $"im" diff_(k+1)$, hence exact linear algebra over $QQ$ (`BigRational`, so no
+//! coefficient growth ever overflows), not just a rank.
 
-use super::complex::Complex;
+use super::{complex::Complex, handle::KSimplexIdx};
 use crate::Dim;
+
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_rational::BigRational;
+use num_traits::{One, Signed, ToPrimitive, Zero};
 
 use std::collections::BTreeMap;
 
@@ -87,6 +98,247 @@ impl Complex {
     }
     triplets
   }
+}
+
+/// An integer $k$-chain: a formal $ZZ$-combination $sum_sigma c_sigma sigma$ of
+/// the k-simplices, coefficients in colex order (indexed by [`KSimplexIdx`]).
+///
+/// The element of $C_k$ dual to a cochain; chains carry no metric, so they live
+/// here in `topology` rather than up in `ddf` with the cochains.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Chain {
+  grade: Dim,
+  coeffs: Vec<i64>,
+}
+impl Chain {
+  pub fn grade(&self) -> Dim {
+    self.grade
+  }
+  /// The coefficient of each k-simplex, in colex order.
+  pub fn coeffs(&self) -> &[i64] {
+    &self.coeffs
+  }
+  /// The simplices carrying a nonzero coefficient, with that coefficient: the
+  /// support of the chain.
+  pub fn support(&self) -> impl Iterator<Item = (KSimplexIdx, i64)> + '_ {
+    self
+      .coeffs
+      .iter()
+      .enumerate()
+      .filter(|(_, &c)| c != 0)
+      .map(|(kidx, &c)| (kidx, c))
+  }
+}
+
+impl Complex {
+  /// Representative cycles whose classes are a basis of the free part of
+  /// $H_k (K; ZZ)$ -- one [`Chain`] per Betti number $b_k$.
+  ///
+  /// Each generator is a k-cycle, $diff_k z = 0$; its class generates a
+  /// $ZZ$-summand of $H_k$, and the $b_k$ classes are independent modulo
+  /// boundaries. For $k = 0$ these are one vertex per connected component; for
+  /// $k = 1$, loops around the holes; at the top grade of a closed manifold, the
+  /// fundamental class.
+  ///
+  /// Representatives, not minimizers: the supporting simplices form *a* cycle in
+  /// the class, chosen by the elimination order, never a shortest one -- optimal
+  /// generators are a separate (hard) problem. Metric-free, and computed exactly
+  /// over $QQ$; the returned coefficients are primitive (their gcd is 1) with the
+  /// first nonzero one positive.
+  pub fn homology_generators(&self, grade: Dim) -> Vec<Chain> {
+    if grade > self.dim() {
+      return Vec::new();
+    }
+    let len = self.nsimplices(grade);
+
+    // A basis of the boundaries $B_k = "im" diff_(k+1) subset.eq Z_k$, and then
+    // the cycles $Z_k = ker diff_k$; a cycle enlarging the span of what came
+    // before is a new generator, so seeding the reducer with $B_k$ first makes
+    // "enlarges the span" mean "is not a boundary".
+    let mut span = EchelonSpan::default();
+    for boundary in self.rational_boundary_columns(grade + 1, len) {
+      span.insert(boundary);
+    }
+    self
+      .rational_cycles(grade)
+      .into_iter()
+      .filter_map(|cycle| {
+        span
+          .insert(cycle)
+          .then(|| primitive_chain(grade, &span.last))
+      })
+      .collect()
+  }
+
+  /// A basis of $Z_k = ker diff_k$ as rational column vectors of length $n_k$,
+  /// from the reduced row echelon form of $diff_k$: each non-pivot (free) column
+  /// yields one kernel vector.
+  fn rational_cycles(&self, grade: Dim) -> Vec<Vec<BigRational>> {
+    let ncols = self.nsimplices(grade);
+    let nrows = if grade == 0 {
+      0
+    } else {
+      self.nsimplices(grade - 1)
+    };
+
+    let mut mat = vec![vec![BigRational::zero(); ncols]; nrows];
+    if grade >= 1 {
+      for (col, sup) in self.skeleton(grade).handle_iter().enumerate() {
+        for (sign, sub) in sup.boundary() {
+          mat[sub.kidx()][col] = BigRational::from_integer(BigInt::from(sign.as_i32()));
+        }
+      }
+    }
+
+    let pivot_cols = reduced_row_echelon(&mut mat, ncols);
+    let is_pivot = {
+      let mut flags = vec![false; ncols];
+      for &c in &pivot_cols {
+        flags[c] = true;
+      }
+      flags
+    };
+
+    (0..ncols)
+      .filter(|c| !is_pivot[*c])
+      .map(|free| {
+        let mut cycle = vec![BigRational::zero(); ncols];
+        cycle[free] = BigRational::one();
+        // The free column, back-substituted through the pivots.
+        for (row, &pivot_col) in pivot_cols.iter().enumerate() {
+          cycle[pivot_col] = -mat[row][free].clone();
+        }
+        cycle
+      })
+      .collect()
+  }
+
+  /// The columns of $diff_(grade)$ as rational vectors of length `len`: each
+  /// `grade`-simplex mapped to its boundary. Empty above the top grade.
+  fn rational_boundary_columns(&self, grade: Dim, len: usize) -> Vec<Vec<BigRational>> {
+    if grade == 0 || grade > self.dim() {
+      return Vec::new();
+    }
+    self
+      .skeleton(grade)
+      .handle_iter()
+      .map(|sup| {
+        let mut col = vec![BigRational::zero(); len];
+        for (sign, sub) in sup.boundary() {
+          col[sub.kidx()] = BigRational::from_integer(BigInt::from(sign.as_i32()));
+        }
+        col
+      })
+      .collect()
+  }
+}
+
+/// An incrementally built row-echelon basis of a subspace of $QQ^n$, keyed by
+/// leading (pivot) coordinate. [`insert`](Self::insert) reduces a vector against
+/// the basis and, if a nonzero remainder survives, records it and reports the
+/// vector as having enlarged the span.
+#[derive(Default)]
+struct EchelonSpan {
+  /// Pivot coordinate -> a basis vector with a leading 1 there.
+  pivots: BTreeMap<usize, Vec<BigRational>>,
+  /// The last inserted (unnormalized) vector, exposed so a caller can turn an
+  /// accepted cycle into a chain without reducing it a second time.
+  last: Vec<BigRational>,
+}
+impl EchelonSpan {
+  /// Reduce `vec` against the current basis. Returns whether it was independent
+  /// (enlarged the span); if so the reduced form is retained as a new pivot and
+  /// the original is kept in [`last`](Self::last).
+  fn insert(&mut self, vec: Vec<BigRational>) -> bool {
+    self.last = vec.clone();
+    let mut reduced = vec;
+    while let Some(lead) = reduced.iter().position(|x| !x.is_zero()) {
+      let Some(pivot) = self.pivots.get(&lead) else {
+        let inv = reduced[lead].recip();
+        for coeff in &mut reduced {
+          *coeff = &*coeff * &inv;
+        }
+        self.pivots.insert(lead, reduced);
+        return true;
+      };
+      let factor = reduced[lead].clone();
+      for (coeff, pivot_coeff) in reduced.iter_mut().zip(pivot) {
+        *coeff = &*coeff - &(&factor * pivot_coeff);
+      }
+    }
+    false
+  }
+}
+
+/// Reduce `mat` (with `ncols` columns) to reduced row echelon form over $QQ$ in
+/// place, returning the pivot column of each pivot row, in row order.
+fn reduced_row_echelon(mat: &mut [Vec<BigRational>], ncols: usize) -> Vec<usize> {
+  let nrows = mat.len();
+  let mut pivot_cols = Vec::new();
+  let mut row = 0;
+  for col in 0..ncols {
+    if row >= nrows {
+      break;
+    }
+    let Some(sel) = (row..nrows).find(|&r| !mat[r][col].is_zero()) else {
+      continue;
+    };
+    mat.swap(row, sel);
+
+    let inv = mat[row][col].recip();
+    for coeff in &mut mat[row] {
+      *coeff = &*coeff * &inv;
+    }
+
+    for r in 0..nrows {
+      if r != row && !mat[r][col].is_zero() {
+        let factor = mat[r][col].clone();
+        let pivot_row = mat[row].clone();
+        for (target, pivot_coeff) in mat[r].iter_mut().zip(&pivot_row) {
+          *target = &*target - &(&factor * pivot_coeff);
+        }
+      }
+    }
+
+    pivot_cols.push(col);
+    row += 1;
+  }
+  pivot_cols
+}
+
+/// Turn a rational cycle into the [`Chain`] with the same direction but integer,
+/// primitive coefficients: clear denominators, divide out their gcd, and fix the
+/// sign so the first nonzero coefficient is positive.
+fn primitive_chain(grade: Dim, cycle: &[BigRational]) -> Chain {
+  let denom_lcm = cycle
+    .iter()
+    .fold(BigInt::one(), |acc, x| acc.lcm(x.denom()));
+  let mut ints: Vec<BigInt> = cycle
+    .iter()
+    .map(|x| x.numer() * (&denom_lcm / x.denom()))
+    .collect();
+
+  let gcd = ints.iter().fold(BigInt::zero(), |acc, x| acc.gcd(x));
+  if !gcd.is_zero() {
+    for x in &mut ints {
+      *x = &*x / &gcd;
+    }
+  }
+  if ints
+    .iter()
+    .find(|x| !x.is_zero())
+    .is_some_and(BigInt::is_negative)
+  {
+    for x in &mut ints {
+      *x = -&*x;
+    }
+  }
+
+  let coeffs = ints
+    .iter()
+    .map(|x| x.to_i64().expect("generator coefficient fits in i64"))
+    .collect();
+  Chain { grade, coeffs }
 }
 
 /// Two primes near $2^30$. Their pairwise product fits in an `i64`, so all
@@ -165,7 +417,126 @@ fn mod_inverse(a: i64, p: i64) -> i64 {
 
 #[cfg(test)]
 mod test {
+  use super::*;
   use crate::gen::cartesian::CartesianMeshInfo;
+  use crate::topology::skeleton::Skeleton;
+
+  /// A square annulus: the $3 times 3$ unit mesh with the middle cell removed,
+  /// so $b_1 = 1$ (one hole).
+  fn annulus() -> Complex {
+    use crate::geometry::coord::simplex::SimplexCoords;
+    let (square, coords) = CartesianMeshInfo::new_unit(2, 3).compute_coord_complex();
+    let cells: Vec<_> = square
+      .cells()
+      .handle_iter()
+      .filter(|cell| {
+        let bc = SimplexCoords::from_simplex_and_coords(cell.simplex(), &coords).barycenter();
+        let inside = |x: f64| 1.0 / 3.0 < x && x < 2.0 / 3.0;
+        !(inside(bc[0]) && inside(bc[1]))
+      })
+      .map(|cell| cell.simplex().clone())
+      .collect();
+    Complex::from_cells(Skeleton::new(cells))
+  }
+
+  /// A spread of complexes with nontrivial homology across the grades.
+  fn test_complexes() -> Vec<Complex> {
+    let mut complexes: Vec<Complex> = (1..=3)
+      .map(|dim| {
+        CartesianMeshInfo::new_unit(dim, 2)
+          .compute_coord_complex()
+          .0
+      })
+      .collect();
+    complexes.push(crate::dim3::mesh_sphere_surface(1).into_coord_complex().0);
+    complexes.push(annulus());
+    complexes
+  }
+
+  /// Whether a chain is a cycle: $diff_k z = 0$.
+  fn is_cycle(complex: &Complex, chain: &Chain) -> bool {
+    let grade = chain.grade();
+    if grade == 0 {
+      return true;
+    }
+    let mut image = vec![0i64; complex.nsimplices(grade - 1)];
+    for (col, sup) in complex.skeleton(grade).handle_iter().enumerate() {
+      let coeff = chain.coeffs()[col];
+      for (sign, sub) in sup.boundary() {
+        image[sub.kidx()] += coeff * i64::from(sign.as_i32());
+      }
+    }
+    image.iter().all(|&x| x == 0)
+  }
+
+  /// One generator per Betti number, in every grade.
+  #[test]
+  fn generators_count_matches_betti() {
+    for complex in test_complexes() {
+      for k in 0..=complex.dim() {
+        assert_eq!(
+          complex.homology_generators(k).len(),
+          complex.betti_number(k)
+        );
+      }
+    }
+  }
+
+  /// Every generator is a cycle.
+  #[test]
+  fn generators_are_cycles() {
+    for complex in test_complexes() {
+      for k in 0..=complex.dim() {
+        for generator in complex.homology_generators(k) {
+          assert!(is_cycle(&complex, &generator), "grade {k}");
+        }
+      }
+    }
+  }
+
+  /// The generator classes are independent modulo boundaries: appended to the
+  /// columns of $diff_(k+1)$ they raise the rank by exactly $b_k$, so no
+  /// generator -- nor any combination -- is itself a boundary.
+  #[test]
+  fn generators_independent_modulo_boundaries() {
+    for complex in test_complexes() {
+      for k in 0..=complex.dim() {
+        let nrows = complex.nsimplices(k);
+        let boundary_cols = if k < complex.dim() {
+          complex.nsimplices(k + 1)
+        } else {
+          0
+        };
+        let mut triplets = if k < complex.dim() {
+          complex.boundary_triplets(k + 1)
+        } else {
+          Vec::new()
+        };
+        for (g, generator) in complex.homology_generators(k).iter().enumerate() {
+          for (kidx, coeff) in generator.support() {
+            triplets.push((kidx, boundary_cols + g, coeff));
+          }
+        }
+        assert_eq!(
+          exact_rank(nrows, &triplets),
+          complex.boundary_rank(k + 1) + complex.betti_number(k),
+          "grade {k}"
+        );
+      }
+    }
+  }
+
+  /// The annulus has one hole, and its $H_1$ generator is a nontrivial loop --
+  /// a cycle around the hole spanning several edges.
+  #[test]
+  fn annulus_generator_is_a_loop() {
+    let complex = annulus();
+    let generators = complex.homology_generators(1);
+    assert_eq!(generators.len(), 1);
+    let loop_ = &generators[0];
+    assert!(is_cycle(&complex, loop_));
+    assert!(loop_.support().count() >= 3);
+  }
 
   /// Euler--Poincaré: the alternating simplex count equals the alternating
   /// Betti sum. A cross-check tying the Betti numbers back to the raw counts.

--- a/crates/manifold/src/topology/homology.rs
+++ b/crates/manifold/src/topology/homology.rs
@@ -1,0 +1,210 @@
+//! Integer simplicial homology of the complex.
+//!
+//! The Betti numbers $b_k = dim H_k (K; ZZ)$ of the chain complex
+//!
+//! $dots.c ->^(diff_(k+1)) C_k ->^(diff_k) C_(k-1) ->^(diff_(k-1)) dots.c$
+//!
+//! read off the ranks of the (integer) boundary operators:
+//!
+//! $b_k = dim ker diff_k - rank diff_(k+1) = n_k - rank diff_k - rank diff_(k+1)$,
+//!
+//! with $n_k$ the number of k-simplices. Metric-free (invariant 5): homology is
+//! a topological invariant, a function of the incidence alone.
+//!
+//! The rank is computed exactly, by Gaussian elimination over a prime field,
+//! never by a floating-point SVD with a tolerance -- a discrete invariant must
+//! not depend on where a singular value falls relative to a magic constant. The
+//! rank over $FF_p$ equals the rational rank unless $p$ divides the product of
+//! the invariant factors (the torsion coefficients), which for a boundary matrix
+//! are tiny; two large primes put the exception out of reach of any representable
+//! mesh. The full torsion of $H_k (K; ZZ)$ is not recovered -- it is invisible to
+//! the de Rham / Hodge side of the library, which lives over $RR$ -- so only the
+//! free rank is returned.
+
+use super::complex::Complex;
+use crate::Dim;
+
+use std::collections::BTreeMap;
+
+impl Complex {
+  /// The Betti numbers $b_0, dots, b_n$ of $K$: the ranks of the free part of
+  /// the integer homology $H_k (K; ZZ)$. A topological invariant, metric-free.
+  ///
+  /// $b_0$ counts connected components, $b_1$ independent loops, and so on.
+  pub fn betti_numbers(&self) -> Vec<usize> {
+    // rank diff_k for k in 0..=n+1; diff_0 and diff_(n+1) map to/from the zero
+    // space and so have rank 0.
+    let ranks: Vec<usize> = (0..=self.dim() + 1)
+      .map(|k| self.boundary_rank(k))
+      .collect();
+    (0..=self.dim())
+      .map(|k| self.nsimplices(k) - ranks[k] - ranks[k + 1])
+      .collect()
+  }
+
+  /// The k-th Betti number $b_k = dim H_k (K; ZZ)$.
+  pub fn betti_number(&self, grade: Dim) -> usize {
+    self.nsimplices(grade) - self.boundary_rank(grade) - self.boundary_rank(grade + 1)
+  }
+
+  /// The Euler characteristic $chi = sum_k (-1)^k n_k = sum_k (-1)^k b_k$.
+  ///
+  /// The two forms agree by Euler--Poincaré; the first is what is computed, and
+  /// their equality is an exact cross-check on the Betti numbers.
+  pub fn euler_characteristic(&self) -> i64 {
+    (0..=self.dim())
+      .map(|k| {
+        let n = self.nsimplices(k) as i64;
+        if k % 2 == 0 {
+          n
+        } else {
+          -n
+        }
+      })
+      .sum()
+  }
+
+  /// $rank diff_k$, the rank of the integer boundary operator
+  /// $diff_k: C_k -> C_(k-1)$. Outside $1 <= k <= n$ the operator maps to/from
+  /// the zero space and has rank 0.
+  fn boundary_rank(&self, grade: Dim) -> usize {
+    if grade == 0 || grade > self.dim() {
+      return 0;
+    }
+    let nrows = self.nsimplices(grade - 1);
+    let triplets = self.boundary_triplets(grade);
+    exact_rank(nrows, &triplets)
+  }
+
+  /// The integer boundary operator $diff_k$ as `(row, col, +-1)` triplets:
+  /// column = k-simplex, row = (k-1)-face, entry = its incidence sign.
+  fn boundary_triplets(&self, grade: Dim) -> Vec<(usize, usize, i64)> {
+    let mut triplets = Vec::new();
+    for (col, sup) in self.skeleton(grade).handle_iter().enumerate() {
+      for (sign, sub) in sup.boundary() {
+        triplets.push((sub.kidx(), col, i64::from(sign.as_i32())));
+      }
+    }
+    triplets
+  }
+}
+
+/// Two primes near $2^30$. Their pairwise product fits in an `i64`, so all
+/// modular arithmetic below stays exact without overflow.
+const PRIMES: [i64; 2] = [1_000_000_007, 1_000_000_009];
+
+/// The exact rank over $QQ$ of the integer matrix given by its `(row, col, val)`
+/// triplets, as the maximum of the ranks over the two prime fields. A single
+/// prime under-counts only if it divides the product of the torsion
+/// coefficients; two large primes would both have to, which no representable
+/// mesh admits.
+fn exact_rank(nrows: usize, triplets: &[(usize, usize, i64)]) -> usize {
+  PRIMES
+    .iter()
+    .map(|&p| rank_mod_p(nrows, triplets, p))
+    .max()
+    .expect("PRIMES is nonempty")
+}
+
+/// The rank over $FF_p$ by sparse Gaussian elimination: reduce each row against
+/// a table of pivot rows keyed by their leading column. Reducing a row's leading
+/// column introduces only later columns, so the leading column strictly advances
+/// and the reduction terminates; a row that survives to a fresh leading column
+/// becomes a new pivot.
+fn rank_mod_p(nrows: usize, triplets: &[(usize, usize, i64)], p: i64) -> usize {
+  let mut rows: Vec<BTreeMap<usize, i64>> = vec![BTreeMap::new(); nrows];
+  for &(r, c, v) in triplets {
+    let entry = rows[r].entry(c).or_insert(0);
+    *entry = (*entry + v).rem_euclid(p);
+  }
+
+  // Column -> a row reduced to leading coefficient 1 at that column.
+  let mut pivots: BTreeMap<usize, BTreeMap<usize, i64>> = BTreeMap::new();
+  let mut rank = 0;
+
+  for mut row in rows {
+    row.retain(|_, v| *v != 0);
+
+    // `next()` on a BTreeMap yields the smallest key: the leading column.
+    while let Some((&lead, &coeff)) = row.iter().next() {
+      let Some(pivot) = pivots.get(&lead) else {
+        // Fresh leading column: normalize to a leading 1 and record the pivot.
+        let inv = mod_inverse(coeff, p);
+        let normalized = row.iter().map(|(&c, &v)| (c, v * inv % p)).collect();
+        pivots.insert(lead, normalized);
+        rank += 1;
+        break;
+      };
+      // row -= coeff * pivot; the pivot has a leading 1 at `lead`.
+      for (&c, &v) in pivot {
+        let entry = row.entry(c).or_insert(0);
+        *entry = (*entry - coeff * v).rem_euclid(p);
+        if *entry == 0 {
+          row.remove(&c);
+        }
+      }
+    }
+  }
+
+  rank
+}
+
+/// The modular inverse $a^(-1) mod p$ for prime $p$, by the extended Euclidean
+/// algorithm. Requires $a not equiv 0$.
+fn mod_inverse(a: i64, p: i64) -> i64 {
+  let (mut t, mut new_t) = (0i64, 1i64);
+  let (mut r, mut new_r) = (p, a.rem_euclid(p));
+  while new_r != 0 {
+    let quot = r / new_r;
+    (t, new_t) = (new_t, t - quot * new_t);
+    (r, new_r) = (new_r, r - quot * new_r);
+  }
+  debug_assert_eq!(r, 1, "argument must be invertible mod p");
+  t.rem_euclid(p)
+}
+
+#[cfg(test)]
+mod test {
+  use crate::gen::cartesian::CartesianMeshInfo;
+
+  /// Euler--Poincaré: the alternating simplex count equals the alternating
+  /// Betti sum. A cross-check tying the Betti numbers back to the raw counts.
+  #[test]
+  fn euler_poincare() {
+    for dim in 1..=3 {
+      let (topology, _) = CartesianMeshInfo::new_unit(dim, 2).compute_coord_complex();
+      let alt_betti: i64 = topology
+        .betti_numbers()
+        .iter()
+        .enumerate()
+        .map(|(k, &b)| if k % 2 == 0 { b as i64 } else { -(b as i64) })
+        .sum();
+      assert_eq!(alt_betti, topology.euler_characteristic(), "dim={dim}");
+    }
+  }
+
+  /// A cube is contractible: $b_0 = 1$ and all higher Betti numbers vanish.
+  #[test]
+  fn cube_is_contractible() {
+    for dim in 1..=3 {
+      let (topology, _) = CartesianMeshInfo::new_unit(dim, 2).compute_coord_complex();
+      let expected: Vec<usize> = std::iter::once(1)
+        .chain(std::iter::repeat_n(0, dim))
+        .collect();
+      assert_eq!(topology.betti_numbers(), expected, "dim={dim}");
+    }
+  }
+
+  /// Poincaré duality on a closed orientable manifold: $b_k = b_(n-k)$. The
+  /// 2-sphere realizes it with Betti numbers $(1, 0, 1)$.
+  #[test]
+  fn sphere_poincare_duality() {
+    let (topology, _) = crate::dim3::mesh_sphere_surface(1).into_coord_complex();
+    let betti = topology.betti_numbers();
+    let n = topology.dim();
+    for k in 0..=n {
+      assert_eq!(betti[k], betti[n - k], "k={k}");
+    }
+    assert_eq!(betti, vec![1, 0, 1]);
+  }
+}


### PR DESCRIPTION
Reworks the mesh's simplicial homology from a single tolerance-based Betti routine into an exact, tested feature, and feeds the result into the Hodge–Laplace solve.

### `manifold`: Betti numbers by exact integer rank

The only homology API was `Complex::homology_dim`, which densified each `f64` boundary operator and took its rank by SVD against `RANK_TOL = 1e-12`. A Betti number is a discrete topological invariant; deciding it by where a singular value lands relative to a fixed tolerance is fragile, and on a large or ill-conditioned complex it can misclassify. The boundary entries are exactly $\{-1, 0, +1\}$, so the rank is now computed exactly, by Gaussian elimination over a prime field — no tolerance anywhere. The rank over $\mathbb{F}_p$ equals the rational rank unless $p$ divides the product of the torsion coefficients (tiny for a boundary matrix); two large primes put that out of reach of any representable mesh. Adds `betti_numbers`, `betti_number` and `euler_characteristic`, sparse and metric-free.

### `manifold`: homology generators

`homology_generators(grade)` returns a representative cycle per Betti number — a `Chain` whose class generates a $\mathbb{Z}$-summand of $H_k$, with the $b_k$ classes independent modulo boundaries. Grade-general by one construction: one vertex per connected component at $k=0$, loops at $k=1$, the fundamental class at the top grade of a closed manifold. It is a basis of $\ker\partial_k$ modulo $\operatorname{im}\partial_{k+1}$, built by exact rational elimination — `BigRational`, so the coefficient growth that would overflow `i128` cannot occur — with the results cleared to primitive integer coefficients. Adds a `Chain` type: an integer $k$-chain, the metric-free dual of a `Cochain`.

### `formoniq`: Betti-derived harmonic count

`solve_hodge_laplace_harmonics` no longer takes `homology_dim` from the caller; it reads `betti_number(grade)` itself. The dimension of the harmonic space is the Betti number (discrete Hodge theorem), now an exact, automatic input rather than a hand-set number in the examples.

### Tests

Law tests across cubes, the sphere and an annulus: Euler–Poincaré ($\sum (-1)^k n_k = \sum (-1)^k b_k$), Poincaré duality ($b_k = b_{n-k}$), one generator per Betti number, each a cycle ($\partial z = 0$), and the classes independent modulo boundaries (appended to $\partial_{k+1}$ they raise the rank by exactly $b_k$).

All four workflow checks pass: `cargo fmt`, `clippy --workspace --all-targets`, `cargo test --workspace`, `cargo doc --workspace --no-deps`.

### Follow-up

The non-eigensolve harmonic construction — project cohomology generators to their unique harmonic representatives, giving labeled harmonics, robust SPD/KKT solves in place of the degenerate eigensolve, and the period/flux conditions for Maxwell on multiply-connected domains — is scoped in #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFCef68f74jiiWEPAFTp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFCef68f74jiiWEPAFTp7y)_