### PR TITLE
common: sparse shift-invert Lanczos eigensolver for the Hodge-Laplace pencil

### DIFF
--- a/crates/common/src/linalg.rs
+++ b/crates/common/src/linalg.rs
@@ -1,2 +1,3 @@
+pub mod eigen;
 pub mod faer;
 pub mod nalgebra;

--- a/crates/common/src/linalg/eigen.rs
+++ b/crates/common/src/linalg/eigen.rs
@@ -1,0 +1,553 @@
+use super::faer::FaerLu;
+use super::nalgebra::{CooMatrix, CsrMatrix, Matrix, Vector};
+
+/// The `k` eigenpairs of $A x = lambda B x$ ($A$, $B$ symmetric, $B$ PSD,
+/// possibly singular) nearest `shift`, ascending by eigenvalue, with
+/// $B$-orthonormal eigenvectors.
+///
+/// Spectral-transformation Lanczos (Ericsson-Ruhe): the wanted eigenpairs of
+/// the original pencil are the extremal eigenpairs of the shift-inverted
+/// operator $T = (A - "shift" B)^(-1) B$, which is self-adjoint in the
+/// $B$-seminorm $angle.l x, y angle.r_B = x^top B y$ even though $B$ may be
+/// singular — the exact structure that makes the mixed Hodge-Laplace pencil's
+/// rank-deficient mass block harmless: null directions of $B$ carry zero
+/// seminorm and are never mistaken for an eigenvector. Block-started, with
+/// block size $k$, so a degenerate eigenvalue of multiplicity up to $k$ — the
+/// harmonic space at `shift = 0` is exactly this case — is resolved in full,
+/// not collapsed onto a single direction the way plain single-vector Lanczos
+/// would. Thick-restarted once the Krylov dimension hits a cap, by simply
+/// re-seeding a fresh expansion from the best Ritz vectors found so far:
+/// self-adjointness of $T$ makes this warm-started restart rediscover the
+/// same projected operator (and fresh residual directions) without a
+/// hand-derived arrowhead correction. Full reorthogonalization throughout,
+/// since the wanted eigenvalues cluster near the shift by construction.
+///
+/// Returned eigenvectors are $B$-seminorm-orthonormal directly whenever $B$
+/// is (locally) nonsingular there; on a singular $B$, one more application of
+/// $T$ recovers the correct null-space component before normalizing — the
+/// null space is invisible to every $B$-inner-product the Lanczos recurrence
+/// computes, so a raw Ritz combination leaves it arbitrary, and $T$'s own
+/// action (via $M$'s off-diagonal coupling) is what fixes it.
+///
+/// Panics if $A - "shift" B$ stays singular (or so ill-conditioned that a
+/// solve is numerically meaningless) after retrying with a perturbed shift,
+/// or if convergence is not reached within the restart budget — diagnostic
+/// panics matching this module's other primitives ([`FaerLu`],
+/// `self_adjoint_eigen`), not a `Result`, since no caller here would
+/// meaningfully recover.
+pub fn sparse_shift_invert_eigen(
+  a: &CsrMatrix,
+  b: &CsrMatrix,
+  shift: f64,
+  k: usize,
+) -> (Vector, Matrix) {
+  let n = a.nrows();
+  assert_eq!(a.nrows(), a.ncols());
+  assert_eq!(b.nrows(), n);
+  assert_eq!(b.ncols(), n);
+
+  let k = k.min(n);
+  if k == 0 {
+    return (Vector::zeros(0), Matrix::zeros(n, 0));
+  }
+
+  let a_norm = inf_norm(a);
+  let b_norm = inf_norm(b);
+  let (lu, used_shift) = factor_with_retry(a, b, shift, a_norm);
+
+  let target_dim = (4 * k).max(2 * k + 20).min(n);
+  let (mut basis, mut bbasis) = seed_block(n, k, b);
+
+  // `proj` needs headroom beyond `target_dim`: the basis transiently
+  // overhangs it by a block's worth of still-unexpanded leftover vectors
+  // (the steady-state queue a block-seeded expansion carries), and every
+  // restart reseeds with at most `2k` vectors — a fixed bound independent of
+  // how many restart cycles have run.
+  let proj_cap = (target_dim + 2 * k).min(n);
+  let mut proj = Matrix::zeros(proj_cap, proj_cap);
+  let mut dim = 0usize;
+
+  // Tight enough for the law tests' oracle comparisons, loose enough to be
+  // reachable on an indefinite mixed-KKT pencil: driving for one more order
+  // of magnitude there just cycles restarts without further improvement
+  // until rounding accumulates into instability.
+  const RESIDUAL_TOL: f64 = 1e-9;
+  const MAX_RESTART_CYCLES: usize = 100;
+
+  for _cycle in 0..=MAX_RESTART_CYCLES {
+    // Breakdown on one vector (no residual left to extend the basis with)
+    // does not mean the whole process is exhausted: a block-seeded or
+    // restarted basis has other, still-unexpanded siblings whose own
+    // diagonal/cross terms are independently valid and still need filling.
+    // Only running out of existing vectors to expand is true exhaustion.
+    while dim < target_dim && dim < basis.len() {
+      expand(&mut basis, &mut bbasis, &mut proj, dim, &lu, b);
+      dim += 1;
+    }
+    let exhausted = dim < target_dim;
+
+    let block = proj.view_range(0..dim, 0..dim).into_owned();
+    let (theta, s) = dense_self_adjoint_eigen(&block);
+
+    // Largest |theta| <=> lambda = used_shift + 1/theta closest to the shift.
+    let mut order: Vec<usize> = (0..dim).collect();
+    order.sort_by(|&i, &j| theta[j].abs().total_cmp(&theta[i].abs()));
+
+    let take = k.min(dim);
+    // The raw Ritz combination is already a good eigenvector whenever B is
+    // (locally) nonsingular. But the B-seminorm-orthonormal basis only ever
+    // sees a vector's B-inner products, so on a singular B its null-space
+    // component is arbitrary — exactly the sigma-component of a mixed
+    // Hodge-Laplace eigenvector. Fix it up only when needed, with one more
+    // application of T = M^(-1) B: T's own action fills in the null
+    // component correctly via M's off-diagonal coupling. Refining
+    // unconditionally would be wrong here too — within a degenerate cluster
+    // (already well resolved) it collapses distinct Ritz directions onto each
+    // other, since T acts as a near-identical scalar on the whole cluster.
+    let ritz = |idx: usize| -> (f64, Vector) {
+      let lambda = used_shift + 1.0 / theta[idx];
+      let y = combine(&basis, |l| s[(l, idx)], dim);
+      let raw_res = residual(a, b, lambda, &y, a_norm, b_norm);
+      if raw_res <= RESIDUAL_TOL {
+        return (lambda, y);
+      }
+      let mut x = lu.solve(&(b * &y));
+      let bnorm = (x.dot(&(b * &x))).sqrt();
+      if bnorm > 0.0 {
+        x /= bnorm;
+      }
+      (lambda, x)
+    };
+
+    let converged = order[..take].iter().all(|&i| {
+      let (lambda, x) = ritz(i);
+      residual(a, b, lambda, &x, a_norm, b_norm) <= RESIDUAL_TOL
+    });
+
+    // Exhaustion means the Krylov space reachable from this starting block is
+    // provably complete: there is nothing further the algorithm could do, so
+    // the Ritz pairs in hand are returned regardless of the residual check —
+    // total on the degenerate boundary rather than looping forever.
+    if converged || exhausted {
+      let mut pairs: Vec<(f64, Vector)> = order[..take].iter().map(|&i| ritz(i)).collect();
+      pairs.sort_by(|p, q| p.0.total_cmp(&q.0));
+      let eigenvals = Vector::from_iterator(pairs.len(), pairs.iter().map(|p| p.0));
+      let eigenvecs = Matrix::from_fn(n, pairs.len(), |i, j| pairs[j].1[i]);
+      return (eigenvals, eigenvecs);
+    }
+
+    // Thick restart: warm-start the next cycle from just the best Ritz
+    // vectors found so far, and let the same expansion loop rediscover the
+    // projected operator (and fresh residual directions) from scratch. Not
+    // carrying the old leftover residual block forward keeps the basis's
+    // transient overhang past `dim` bounded by a fixed multiple of `k` across
+    // arbitrarily many restart cycles, rather than growing with each one.
+    let keep = (2 * k).min(target_dim.saturating_sub(1)).max(1);
+
+    let mut new_basis = Vec::with_capacity(keep);
+    let mut new_bbasis = Vec::with_capacity(keep);
+    for &idx in &order[..keep] {
+      new_basis.push(combine(&basis, |l| s[(l, idx)], dim));
+      new_bbasis.push(combine(&bbasis, |l| s[(l, idx)], dim));
+    }
+
+    basis = new_basis;
+    bbasis = new_bbasis;
+    proj = Matrix::zeros(proj_cap, proj_cap);
+    dim = 0;
+  }
+
+  panic!(
+    "sparse_shift_invert_eigen: exceeded {MAX_RESTART_CYCLES} restart cycles \
+     converging {k} eigenpair(s) near shift {shift}"
+  );
+}
+
+/// Applies $T = M^(-1) B$ to `basis[idx]`, reorthogonalizes against every
+/// vector in `basis` so far (not just up to `idx`: a block-seeded or
+/// restarted basis has siblings past `idx` still awaiting their own
+/// expansion), and appends the $B$-normalized residual. Fills row/column
+/// `idx` of `proj` unconditionally; returns `None` (breakdown, no vector
+/// appended) when the residual's $B$-seminorm signals the reachable
+/// invariant subspace is exhausted.
+fn expand(
+  basis: &mut Vec<Vector>,
+  bbasis: &mut Vec<Vector>,
+  proj: &mut Matrix,
+  idx: usize,
+  lu: &FaerLu,
+  b: &CsrMatrix,
+) -> Option<f64> {
+  let mut w = lu.solve(&bbasis[idx]);
+
+  let mut h = vec![0.0; basis.len()];
+  // Two passes of modified Gram-Schmidt ("twice is enough") in the B-inner
+  // product.
+  for _pass in 0..2 {
+    for (j, (vj, bvj)) in basis.iter().zip(bbasis.iter()).enumerate() {
+      let c = w.dot(bvj);
+      h[j] += c;
+      w.axpy(-c, vj, 1.0);
+    }
+  }
+  for (j, &hj) in h.iter().enumerate() {
+    proj[(j, idx)] = hj;
+    proj[(idx, j)] = hj;
+  }
+
+  let bw = b * &w;
+  let beta_sq = w.dot(&bw);
+  const BREAKDOWN_TOL_SQ: f64 = 1e-20;
+  if beta_sq <= BREAKDOWN_TOL_SQ {
+    return None;
+  }
+  let beta = beta_sq.sqrt();
+  basis.push(&w / beta);
+  bbasis.push(&bw / beta);
+  Some(beta)
+}
+
+/// `bs` mutually $B$-orthonormal deterministic pseudo-random seed vectors
+/// (fewer, if $B$'s positive part cannot support `bs` independent
+/// directions): the starting block whose width sets the maximum eigenvalue
+/// multiplicity the solve can resolve in one pass.
+fn seed_block(n: usize, bs: usize, b: &CsrMatrix) -> (Vec<Vector>, Vec<Vector>) {
+  let mut basis = Vec::with_capacity(bs);
+  let mut bbasis = Vec::with_capacity(bs);
+  let mut seed = 0u64;
+  while basis.len() < bs && seed < bs as u64 * 32 + 32 {
+    let mut v = Vector::from_iterator(n, (0..n).map(|i| pseudo_random(seed, i as u64)));
+    seed += 1;
+    for _pass in 0..2 {
+      for (vj, bvj) in basis.iter().zip(bbasis.iter()) {
+        let c: f64 = v.dot(bvj);
+        v.axpy(-c, vj, 1.0);
+      }
+    }
+    let bv = b * &v;
+    let norm_sq: f64 = v.dot(&bv);
+    const SEED_TOL: f64 = 1e-24;
+    if norm_sq > SEED_TOL {
+      let norm = norm_sq.sqrt();
+      basis.push(&v / norm);
+      bbasis.push(&bv / norm);
+    }
+  }
+  assert!(
+    !basis.is_empty(),
+    "sparse_shift_invert_eigen: B has no reachable positive-seminorm direction; \
+     the pencil has no finite eigenvalue to seek"
+  );
+  (basis, bbasis)
+}
+
+/// A deterministic splitmix64-style fill, so the solve is reproducible
+/// without pulling in a `rand` dependency for this one internal use.
+fn pseudo_random(seed: u64, index: u64) -> f64 {
+  let mut z = seed
+    .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+    .wrapping_add(index.wrapping_mul(0xD1B5_4A32_D192_ED03))
+    .wrapping_add(0x9E37_79B9_7F4A_7C15);
+  z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+  z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+  z ^= z >> 31;
+  (z >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+}
+
+fn combine(vecs: &[Vector], coeff: impl Fn(usize) -> f64, dim: usize) -> Vector {
+  let mut out = Vector::zeros(vecs[0].nrows());
+  for (l, v) in vecs.iter().enumerate().take(dim) {
+    out.axpy(coeff(l), v, 1.0);
+  }
+  out
+}
+
+fn residual(
+  a: &CsrMatrix,
+  b: &CsrMatrix,
+  lambda: f64,
+  x: &Vector,
+  a_norm: f64,
+  b_norm: f64,
+) -> f64 {
+  let ax = a * x;
+  let bx = b * x;
+  let r = &ax - lambda * &bx;
+  let xnorm = x.norm();
+  let scale = a_norm * xnorm + lambda.abs() * b_norm * xnorm;
+  if scale > 0.0 {
+    r.norm() / scale
+  } else {
+    r.norm()
+  }
+}
+
+fn inf_norm(m: &CsrMatrix) -> f64 {
+  let mut row_sums = vec![0.0; m.nrows()];
+  for (r, _, &v) in m.triplet_iter() {
+    row_sums[r] += v.abs();
+  }
+  row_sums.into_iter().fold(0.0_f64, f64::max)
+}
+
+/// $M = A - "shift" B$, factored via sparse LU. Retries with a
+/// scale-perturbed shift on singular factorization — generic only when
+/// `shift` lands exactly on an eigenvalue, which `shift = 0` does whenever
+/// the pencil has a harmonic space.
+fn factor_with_retry(a: &CsrMatrix, b: &CsrMatrix, shift: f64, a_norm: f64) -> (FaerLu, f64) {
+  const MAX_ATTEMPTS: usize = 16;
+  let eps0 = f64::EPSILON.sqrt() * a_norm.max(1.0);
+  let mut current_shift = shift;
+  for attempt in 0..MAX_ATTEMPTS {
+    let m = shifted_matrix(a, b, current_shift);
+    if let Some(lu) = FaerLu::try_new(m.clone()) {
+      // A merely non-singular-in-exact-arithmetic M can still be
+      // catastrophically ill-conditioned in floating point — `shift`
+      // landing so close to an eigenvalue that `sp_lu` "succeeds" but
+      // amplifies noise into the near-null direction. The forward residual
+      // `M x - rhs` stays small even then (M nearly annihilates that
+      // direction), so it can't see the problem; round-tripping a probe
+      // vector through solve and checking it comes back unchanged can.
+      let probe = Vector::from_iterator(
+        m.nrows(),
+        (0..m.nrows()).map(|i| pseudo_random(!0, i as u64)),
+      );
+      let rhs = &m * &probe;
+      let resolved = lu.solve(&rhs);
+      let stable = (&resolved - &probe).norm() <= 1e-6 * probe.norm().max(1.0);
+      if stable {
+        return (lu, current_shift);
+      }
+    }
+    current_shift = shift + eps0 * 2f64.powi(attempt as i32);
+  }
+  panic!(
+    "sparse_shift_invert_eigen: A - shift*B remained singular after \
+     {MAX_ATTEMPTS} perturbations of shift {shift}"
+  );
+}
+
+fn shifted_matrix(a: &CsrMatrix, b: &CsrMatrix, shift: f64) -> CsrMatrix {
+  let mut coo = CooMatrix::new(a.nrows(), a.ncols());
+  for (r, c, &v) in a.triplet_iter() {
+    coo.push(r, c, v);
+  }
+  for (r, c, &v) in b.triplet_iter() {
+    coo.push(r, c, -shift * v);
+  }
+  CsrMatrix::from(&coo)
+}
+
+fn dense_self_adjoint_eigen(m: &Matrix) -> (Vector, Matrix) {
+  let n = m.nrows();
+  let fm = faer::Mat::from_fn(n, n, |i, j| m[(i, j)]);
+  let eig = fm.self_adjoint_eigen(faer::Side::Lower).unwrap();
+  let vals = eig.S().column_vector();
+  let vecs = eig.U();
+  let eigenvals = Vector::from_iterator(n, (0..n).map(|i| *vals.get(i)));
+  let eigenvecs = Matrix::from_fn(n, n, |i, j| *vecs.get(i, j));
+  (eigenvals, eigenvecs)
+}
+
+#[cfg(test)]
+mod test {
+  use super::sparse_shift_invert_eigen;
+  use crate::linalg::nalgebra::{CooMatrix, CsrMatrix, Matrix, Vector};
+
+  fn symmetric(n: usize, f: impl Fn(usize, usize) -> f64) -> Matrix {
+    Matrix::from_fn(n, n, |i, j| f(i.min(j), i.max(j)))
+  }
+
+  fn csr(m: &Matrix) -> CsrMatrix {
+    m.into()
+  }
+
+  /// Every returned pair solves the pencil: $A x = lambda B x$.
+  #[test]
+  fn pairs_solve_the_pencil() {
+    let n = 6;
+    let a = symmetric(n, |i, j| ((i * 7 + j * 3) % 11) as f64 - 5.0);
+    // SPD: diagonally dominant with a positive diagonal.
+    let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
+
+    for nev in 1..=n {
+      let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, nev);
+      for k in 0..vals.len() {
+        let x = vecs.column(k).into_owned();
+        let residual = (&a * &x - vals[k] * (&b * &x)).norm();
+        assert!(residual < 1e-9, "nev={nev} k={k} residual={residual:e}");
+      }
+    }
+  }
+
+  /// With $B = I$ the pencil is the standard symmetric eigenproblem, so the
+  /// eigenvalues nearest $0$ must match a dense symmetric EVD oracle.
+  #[test]
+  fn matches_symmetric_evd_oracle() {
+    let n = 7;
+    let a = symmetric(n, |i, j| ((i * 5 + j * 2) % 13) as f64 - 6.0);
+    let id = Matrix::identity(n, n);
+
+    let mut oracle: Vec<f64> = a.clone().symmetric_eigenvalues().iter().copied().collect();
+    oracle.sort_by(|x, y| x.abs().total_cmp(&y.abs()));
+
+    for nev in 1..=n {
+      let (vals, _) = sparse_shift_invert_eigen(&csr(&a), &csr(&id), 0.0, nev);
+      let mut got: Vec<f64> = vals.iter().copied().collect();
+      let mut want = oracle[..nev].to_vec();
+      got.sort_by(f64::total_cmp);
+      want.sort_by(f64::total_cmp);
+      for (g, w) in got.iter().zip(&want) {
+        assert!((g - w).abs() < 1e-8, "nev={nev}: got {g} want {w}");
+      }
+    }
+  }
+
+  /// Eigenvectors are $B$-orthonormal.
+  #[test]
+  fn eigenvectors_are_b_orthonormal() {
+    let n = 6;
+    let a = symmetric(n, |i, j| if i == j { 2.0 * n as f64 } else { 0.5 });
+    let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
+
+    let (_, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, n);
+    for k in 0..vecs.ncols() {
+      for l in 0..vecs.ncols() {
+        let vk = vecs.column(k).into_owned();
+        let vl = vecs.column(l).into_owned();
+        let ip = vk.dot(&(&b * &vl));
+        let want = if k == l { 1.0 } else { 0.0 };
+        assert!((ip - want).abs() < 1e-8, "k={k} l={l} got {ip} want {want}");
+      }
+    }
+  }
+
+  /// A singular, indefinite-adjacent $B$ (the mixed-formulation regime): a
+  /// null direction of $B$ is never selected, and the finite pairs returned
+  /// still solve the pencil, even shifted away from $0$.
+  #[test]
+  fn excludes_the_null_space_of_b() {
+    let n = 5;
+    let a = symmetric(n, |i, j| ((i * 3 + j * 7) % 11) as f64 - 5.0);
+    // PSD but rank-deficient: the last coordinate carries no mass.
+    let b = Matrix::from_fn(n, n, |i, j| if i == j && i + 1 < n { 1.0 } else { 0.0 });
+
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.1, n - 1);
+    assert_eq!(vals.len(), n - 1);
+    for k in 0..vals.len() {
+      assert!(vals[k].is_finite());
+      let x: Vector = vecs.column(k).into_owned();
+      let residual = (&a * &x - vals[k] * (&b * &x)).norm();
+      assert!(residual < 1e-8, "k={k} residual={residual:e}");
+    }
+  }
+
+  /// The $1 times 1$ (and, via `k = 0`, empty) base case — the $0$-manifold's
+  /// Hodge-Laplace pencil.
+  #[test]
+  fn solves_the_scalar_pencil() {
+    let a = Matrix::from_element(1, 1, 3.0);
+    let b = Matrix::from_element(1, 1, 4.0);
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 3);
+    assert_eq!(vals.len(), 1);
+    assert!((vals[0] - 3.0 / 4.0).abs() < 1e-9);
+    let x: Vector = vecs.column(0).into_owned();
+    assert!(
+      (x.dot(&(&b * &x)) - 1.0).abs() < 1e-9,
+      "eigenvector is B-normalized"
+    );
+    assert!((&a * &x - vals[0] * (&b * &x)).norm() < 1e-9);
+
+    let (vals0, vecs0) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 0);
+    assert_eq!(vals0.len(), 0);
+    assert_eq!(vecs0.ncols(), 0);
+  }
+
+  /// A degenerate cluster of multiplicity `m` sitting exactly at the shift —
+  /// the harmonic-space case, `shift = 0` on a pencil where $A$ itself is
+  /// singular — is fully resolved (not collapsed to one direction), forcing
+  /// the shift-retry path every time.
+  #[test]
+  fn resolves_a_degenerate_cluster_at_the_shift() {
+    let m = 3;
+    let rest = 4;
+    let n = m + rest;
+    // B = I. A has an m-fold zero eigenvalue (the first m basis vectors) and
+    // `rest` nonzero eigenvalues elsewhere, mixed by a fixed orthonormal-ish
+    // change of basis so the cluster isn't axis-aligned with the seed.
+    let b = Matrix::identity(n, n);
+    let diag = Matrix::from_fn(n, n, |i, j| {
+      if i != j || i < m {
+        0.0
+      } else {
+        (i - m + 1) as f64
+      }
+    });
+    // A small fixed rotation mixing coordinates, so the zero-eigenspace is
+    // not simply the first m standard basis vectors.
+    let rot = Matrix::from_fn(n, n, |i, j| ((i * 5 + j * 3 + 1) % 7) as f64 - 3.0);
+    let rot = rot.clone() + rot.transpose() + Matrix::identity(n, n) * (2.0 * n as f64);
+    let a = &rot * &diag * &rot.transpose();
+    let a = (&a + a.transpose()) * 0.5;
+
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, m);
+    assert_eq!(vals.len(), m);
+    for &v in vals.iter() {
+      assert!(v.abs() < 1e-6, "expected a near-zero eigenvalue, got {v}");
+    }
+    for k in 0..m {
+      let x = vecs.column(k).into_owned();
+      let residual = (&a * &x - vals[k] * &x).norm();
+      assert!(residual < 1e-6, "k={k} residual={residual:e}");
+    }
+    // The m recovered eigenvectors are linearly independent (B-orthonormal),
+    // so together they span the whole zero-eigenspace rather than repeating
+    // one direction.
+    let gram = vecs.transpose() * &vecs;
+    let dev = (&gram - Matrix::identity(m, m)).norm();
+    assert!(
+      dev < 1e-6,
+      "recovered directions are not mutually independent: {gram}"
+    );
+  }
+
+  /// The 1D Dirichlet Laplacian (tridiagonal, $B = I$), whose eigenvalues have
+  /// the closed form $lambda_j = 2 - 2 cos(j pi \/ (N + 1))$ — an oracle with
+  /// no dense EVD needed at any size, including $N$ in the low thousands,
+  /// where dense QZ has no business running.
+  #[test]
+  fn handles_a_large_sparse_pencil() {
+    let n = 3000;
+    let nev = 5;
+
+    let mut coo = CooMatrix::new(n, n);
+    for i in 0..n {
+      coo.push(i, i, 2.0);
+      if i + 1 < n {
+        coo.push(i, i + 1, -1.0);
+        coo.push(i + 1, i, -1.0);
+      }
+    }
+    let a = CsrMatrix::from(&coo);
+    let mut ident = CooMatrix::new(n, n);
+    for i in 0..n {
+      ident.push(i, i, 1.0);
+    }
+    let b = CsrMatrix::from(&ident);
+
+    let (vals, vecs) = sparse_shift_invert_eigen(&a, &b, 0.0, nev);
+    assert_eq!(vals.len(), nev);
+    for k in 0..nev {
+      let x = vecs.column(k).into_owned();
+      let residual = (&a * &x - vals[k] * (&b * &x)).norm();
+      assert!(residual < 1e-6, "k={k} residual={residual:e}");
+
+      let want = 2.0 - 2.0 * (((k + 1) as f64 * std::f64::consts::PI) / (n as f64 + 1.0)).cos();
+      assert!(
+        (vals[k] - want).abs() < 1e-6,
+        "k={k}: got {} want {want}",
+        vals[k]
+      );
+    }
+  }
+}

--- a/crates/common/src/linalg/eigen.rs
+++ b/crates/common/src/linalg/eigen.rs
@@ -1,46 +1,68 @@
 use super::faer::FaerLu;
 use super::nalgebra::{CooMatrix, CsrMatrix, Matrix, Vector};
 
+use std::fmt;
+
+/// Why [`sparse_shift_invert_eigen`] could not produce the wanted eigenpairs.
+///
+/// Not every failure is a bug in the caller's pencil: exceeding the iteration
+/// budget says only that *this* budget was too small, which an interactive
+/// caller can report and move on from.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EigenError {
+  /// $B$'s positive part is trivial, so the pencil has no finite eigenvalue.
+  NoFiniteEigenvalue,
+  /// $A - "shift" B$ stayed singular, or too ill-conditioned to solve with,
+  /// under every perturbation of the shift tried.
+  SingularPencil { shift: f64 },
+  /// The restart budget ran out with the worst wanted pair still at
+  /// `residual`.
+  NotConverged { shift: f64, residual: f64 },
+}
+impl fmt::Display for EigenError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      Self::NoFiniteEigenvalue => write!(f, "B has no positive-seminorm direction"),
+      Self::SingularPencil { shift } => write!(
+        f,
+        "A - {shift}*B is singular under every shift perturbation"
+      ),
+      Self::NotConverged { shift, residual } => {
+        write!(
+          f,
+          "no convergence near shift {shift}; worst residual {residual:e}"
+        )
+      }
+    }
+  }
+}
+impl std::error::Error for EigenError {}
+
 /// The `k` eigenpairs of $A x = lambda B x$ ($A$, $B$ symmetric, $B$ PSD,
 /// possibly singular) nearest `shift`, ascending by eigenvalue, with
-/// $B$-orthonormal eigenvectors.
+/// $B$-orthonormal eigenvectors. Fewer than `k` when $B$'s positive part
+/// cannot support `k` independent directions.
 ///
 /// Spectral-transformation Lanczos (Ericsson-Ruhe): the wanted eigenpairs of
-/// the original pencil are the extremal eigenpairs of the shift-inverted
-/// operator $T = (A - "shift" B)^(-1) B$, which is self-adjoint in the
-/// $B$-seminorm $angle.l x, y angle.r_B = x^top B y$ even though $B$ may be
-/// singular — the exact structure that makes the mixed Hodge-Laplace pencil's
-/// rank-deficient mass block harmless: null directions of $B$ carry zero
-/// seminorm and are never mistaken for an eigenvector. Block-started, with
-/// block size $k$, so a degenerate eigenvalue of multiplicity up to $k$ — the
-/// harmonic space at `shift = 0` is exactly this case — is resolved in full,
-/// not collapsed onto a single direction the way plain single-vector Lanczos
-/// would. Thick-restarted once the Krylov dimension hits a cap, by simply
-/// re-seeding a fresh expansion from the best Ritz vectors found so far:
-/// self-adjointness of $T$ makes this warm-started restart rediscover the
-/// same projected operator (and fresh residual directions) without a
-/// hand-derived arrowhead correction. Full reorthogonalization throughout,
-/// since the wanted eigenvalues cluster near the shift by construction.
+/// the pencil are the extremal eigenpairs of $T = (A - "shift" B)^(-1) B$,
+/// which is self-adjoint in the $B$-seminorm even for singular $B$ — the
+/// structure that makes the mixed Hodge-Laplace pencil's rank-deficient mass
+/// block harmless, since null directions of $B$ carry zero seminorm and are
+/// never mistaken for an eigenvector. Block-started with block size $k$, so an
+/// eigenvalue of multiplicity up to $k$ — the harmonic space at `shift = 0` —
+/// is resolved in full rather than collapsed onto one direction. Restarted
+/// from the best Ritz vectors on hitting the Krylov cap, with full
+/// reorthogonalization throughout.
 ///
-/// Returned eigenvectors are $B$-seminorm-orthonormal directly whenever $B$
-/// is (locally) nonsingular there; on a singular $B$, one more application of
-/// $T$ recovers the correct null-space component before normalizing — the
-/// null space is invisible to every $B$-inner-product the Lanczos recurrence
-/// computes, so a raw Ritz combination leaves it arbitrary, and $T$'s own
-/// action (via $M$'s off-diagonal coupling) is what fixes it.
-///
-/// Panics if $A - "shift" B$ stays singular (or so ill-conditioned that a
-/// solve is numerically meaningless) after retrying with a perturbed shift,
-/// or if convergence is not reached within the restart budget — diagnostic
-/// panics matching this module's other primitives ([`FaerLu`],
-/// `self_adjoint_eigen`), not a `Result`, since no caller here would
-/// meaningfully recover.
+/// A raw Ritz vector's $ker B$ component is arbitrary, the $B$-inner products
+/// the recurrence computes being blind to it. One more application of $T$
+/// recovers it through $M$'s off-diagonal coupling.
 pub fn sparse_shift_invert_eigen(
   a: &CsrMatrix,
   b: &CsrMatrix,
   shift: f64,
   k: usize,
-) -> (Vector, Matrix) {
+) -> Result<(Vector, Matrix), EigenError> {
   let n = a.nrows();
   assert_eq!(a.nrows(), a.ncols());
   assert_eq!(b.nrows(), n);
@@ -48,38 +70,37 @@ pub fn sparse_shift_invert_eigen(
 
   let k = k.min(n);
   if k == 0 {
-    return (Vector::zeros(0), Matrix::zeros(n, 0));
+    return Ok((Vector::zeros(0), Matrix::zeros(n, 0)));
   }
 
   let a_norm = inf_norm(a);
   let b_norm = inf_norm(b);
-  let (lu, used_shift) = factor_with_retry(a, b, shift, a_norm);
+  let (lu, used_shift) = factor_with_retry(a, b, shift, a_norm)?;
 
   let target_dim = (4 * k).max(2 * k + 20).min(n);
-  let (mut basis, mut bbasis) = seed_block(n, k, b);
+  let (mut basis, mut bbasis) = seed_block(n, k, b)?;
 
-  // `proj` needs headroom beyond `target_dim`: the basis transiently
-  // overhangs it by a block's worth of still-unexpanded leftover vectors
-  // (the steady-state queue a block-seeded expansion carries), and every
-  // restart reseeds with at most `2k` vectors — a fixed bound independent of
-  // how many restart cycles have run.
+  // The basis overhangs `target_dim` by a block's worth of still-unexpanded
+  // leftovers, and a restart reseeds with at most `2k` — a bound independent
+  // of how many cycles have run.
   let proj_cap = (target_dim + 2 * k).min(n);
   let mut proj = Matrix::zeros(proj_cap, proj_cap);
   let mut dim = 0usize;
 
-  // Tight enough for the law tests' oracle comparisons, loose enough to be
-  // reachable on an indefinite mixed-KKT pencil: driving for one more order
-  // of magnitude there just cycles restarts without further improvement
-  // until rounding accumulates into instability.
+  // The backward error accepted per pair: the returned `x` is exact for a
+  // pencil perturbed by this much relative to $||A||$ and $||B||$. The floor
+  // is set by the shift-invert solve, accurate to $kappa(A - sigma B)
+  // epsilon$; on the mixed KKT pencil that conditioning grows like $h^(-2)$,
+  // so a tighter demand sits below the achievable backward error and only
+  // spins restarts.
   const RESIDUAL_TOL: f64 = 1e-9;
   const MAX_RESTART_CYCLES: usize = 100;
 
+  let mut worst = f64::INFINITY;
   for _cycle in 0..=MAX_RESTART_CYCLES {
-    // Breakdown on one vector (no residual left to extend the basis with)
-    // does not mean the whole process is exhausted: a block-seeded or
-    // restarted basis has other, still-unexpanded siblings whose own
-    // diagonal/cross terms are independently valid and still need filling.
-    // Only running out of existing vectors to expand is true exhaustion.
+    // Breakdown on one vector leaves the block's other, still-unexpanded
+    // siblings independently valid; only running out of vectors to expand is
+    // true exhaustion of the reachable invariant subspace.
     while dim < target_dim && dim < basis.len() {
       expand(&mut basis, &mut bbasis, &mut proj, dim, &lu, b);
       dim += 1;
@@ -94,54 +115,45 @@ pub fn sparse_shift_invert_eigen(
     order.sort_by(|&i, &j| theta[j].abs().total_cmp(&theta[i].abs()));
 
     let take = k.min(dim);
-    // The raw Ritz combination is already a good eigenvector whenever B is
-    // (locally) nonsingular. But the B-seminorm-orthonormal basis only ever
-    // sees a vector's B-inner products, so on a singular B its null-space
-    // component is arbitrary — exactly the sigma-component of a mixed
-    // Hodge-Laplace eigenvector. Fix it up only when needed, with one more
-    // application of T = M^(-1) B: T's own action fills in the null
-    // component correctly via M's off-diagonal coupling. Refining
-    // unconditionally would be wrong here too — within a degenerate cluster
-    // (already well resolved) it collapses distinct Ritz directions onto each
-    // other, since T acts as a near-identical scalar on the whole cluster.
-    let ritz = |idx: usize| -> (f64, Vector) {
-      let lambda = used_shift + 1.0 / theta[idx];
-      let y = combine(&basis, |l| s[(l, idx)], dim);
-      let raw_res = residual(a, b, lambda, &y, a_norm, b_norm);
-      if raw_res <= RESIDUAL_TOL {
-        return (lambda, y);
-      }
-      let mut x = lu.solve(&(b * &y));
-      let bnorm = (x.dot(&(b * &x))).sqrt();
-      if bnorm > 0.0 {
-        x /= bnorm;
-      }
-      (lambda, x)
+    let pairs: Vec<(f64, Vector, f64)> = {
+      let ritz = |idx: usize| -> (f64, Vector, f64) {
+        let lambda = used_shift + 1.0 / theta[idx];
+        let y = combine(&basis, |l| s[(l, idx)], dim);
+        let raw_res = residual(a, b, lambda, &y, a_norm, b_norm);
+        // Refine only when the raw pair misses: on a nonsingular $B$ it is
+        // already the answer, and one $T$-application on a converged pair only
+        // reintroduces the solve's own error.
+        if raw_res <= RESIDUAL_TOL {
+          return (lambda, y, raw_res);
+        }
+        let mut x = lu.solve(&(b * &y));
+        let bnorm = x.dot(&(b * &x)).sqrt();
+        if bnorm > 0.0 {
+          x /= bnorm;
+        }
+        let res = residual(a, b, lambda, &x, a_norm, b_norm);
+        (lambda, x, res)
+      };
+      order[..take].iter().map(|&i| ritz(i)).collect()
     };
 
-    let converged = order[..take].iter().all(|&i| {
-      let (lambda, x) = ritz(i);
-      residual(a, b, lambda, &x, a_norm, b_norm) <= RESIDUAL_TOL
-    });
+    worst = pairs.iter().map(|p| p.2).fold(0.0_f64, f64::max);
 
-    // Exhaustion means the Krylov space reachable from this starting block is
-    // provably complete: there is nothing further the algorithm could do, so
-    // the Ritz pairs in hand are returned regardless of the residual check —
-    // total on the degenerate boundary rather than looping forever.
-    if converged || exhausted {
-      let mut pairs: Vec<(f64, Vector)> = order[..take].iter().map(|&i| ritz(i)).collect();
+    // Exhaustion means the Krylov space reachable from this block is complete:
+    // nothing further is available, so return what is in hand rather than
+    // looping — total on the degenerate boundary.
+    if worst <= RESIDUAL_TOL || exhausted {
+      let mut pairs = pairs;
       pairs.sort_by(|p, q| p.0.total_cmp(&q.0));
       let eigenvals = Vector::from_iterator(pairs.len(), pairs.iter().map(|p| p.0));
       let eigenvecs = Matrix::from_fn(n, pairs.len(), |i, j| pairs[j].1[i]);
-      return (eigenvals, eigenvecs);
+      return Ok((eigenvals, eigenvecs));
     }
 
-    // Thick restart: warm-start the next cycle from just the best Ritz
-    // vectors found so far, and let the same expansion loop rediscover the
-    // projected operator (and fresh residual directions) from scratch. Not
-    // carrying the old leftover residual block forward keeps the basis's
-    // transient overhang past `dim` bounded by a fixed multiple of `k` across
-    // arbitrarily many restart cycles, rather than growing with each one.
+    // Restart from the best Ritz vectors alone, letting the same expansion
+    // loop rediscover the projected operator and fresh residual directions.
+    // Dropping the old leftovers is what keeps the basis's overhang past `dim`
+    // bounded across arbitrarily many cycles.
     let keep = (2 * k).min(target_dim.saturating_sub(1)).max(1);
 
     let mut new_basis = Vec::with_capacity(keep);
@@ -157,19 +169,17 @@ pub fn sparse_shift_invert_eigen(
     dim = 0;
   }
 
-  panic!(
-    "sparse_shift_invert_eigen: exceeded {MAX_RESTART_CYCLES} restart cycles \
-     converging {k} eigenpair(s) near shift {shift}"
-  );
+  Err(EigenError::NotConverged {
+    shift,
+    residual: worst,
+  })
 }
 
-/// Applies $T = M^(-1) B$ to `basis[idx]`, reorthogonalizes against every
-/// vector in `basis` so far (not just up to `idx`: a block-seeded or
-/// restarted basis has siblings past `idx` still awaiting their own
-/// expansion), and appends the $B$-normalized residual. Fills row/column
-/// `idx` of `proj` unconditionally; returns `None` (breakdown, no vector
-/// appended) when the residual's $B$-seminorm signals the reachable
-/// invariant subspace is exhausted.
+/// Applies $T = M^(-1) B$ to `basis[idx]`, reorthogonalizes against the whole
+/// basis (not just up to `idx`: siblings past it still await their own
+/// expansion), fills row/column `idx` of `proj`, and appends the
+/// $B$-normalized residual — unless its $B$-seminorm has broken down, in which
+/// case `proj` is still complete for `idx` and nothing is appended.
 fn expand(
   basis: &mut Vec<Vector>,
   bbasis: &mut Vec<Vector>,
@@ -177,7 +187,7 @@ fn expand(
   idx: usize,
   lu: &FaerLu,
   b: &CsrMatrix,
-) -> Option<f64> {
+) {
   let mut w = lu.solve(&bbasis[idx]);
 
   let mut h = vec![0.0; basis.len()];
@@ -199,19 +209,22 @@ fn expand(
   let beta_sq = w.dot(&bw);
   const BREAKDOWN_TOL_SQ: f64 = 1e-20;
   if beta_sq <= BREAKDOWN_TOL_SQ {
-    return None;
+    return;
   }
   let beta = beta_sq.sqrt();
   basis.push(&w / beta);
   bbasis.push(&bw / beta);
-  Some(beta)
 }
 
 /// `bs` mutually $B$-orthonormal deterministic pseudo-random seed vectors
-/// (fewer, if $B$'s positive part cannot support `bs` independent
-/// directions): the starting block whose width sets the maximum eigenvalue
-/// multiplicity the solve can resolve in one pass.
-fn seed_block(n: usize, bs: usize, b: &CsrMatrix) -> (Vec<Vector>, Vec<Vector>) {
+/// (fewer, if $B$'s positive part cannot support `bs` independent directions):
+/// the starting block, whose width is the largest eigenvalue multiplicity the
+/// solve can resolve in one pass.
+fn seed_block(
+  n: usize,
+  bs: usize,
+  b: &CsrMatrix,
+) -> Result<(Vec<Vector>, Vec<Vector>), EigenError> {
   let mut basis = Vec::with_capacity(bs);
   let mut bbasis = Vec::with_capacity(bs);
   let mut seed = 0u64;
@@ -233,16 +246,14 @@ fn seed_block(n: usize, bs: usize, b: &CsrMatrix) -> (Vec<Vector>, Vec<Vector>) 
       bbasis.push(&bv / norm);
     }
   }
-  assert!(
-    !basis.is_empty(),
-    "sparse_shift_invert_eigen: B has no reachable positive-seminorm direction; \
-     the pencil has no finite eigenvalue to seek"
-  );
-  (basis, bbasis)
+  if basis.is_empty() {
+    return Err(EigenError::NoFiniteEigenvalue);
+  }
+  Ok((basis, bbasis))
 }
 
-/// A deterministic splitmix64-style fill, so the solve is reproducible
-/// without pulling in a `rand` dependency for this one internal use.
+/// A deterministic splitmix64-style fill, so the solve is reproducible without
+/// pulling in a `rand` dependency for this one internal use.
 fn pseudo_random(seed: u64, index: u64) -> f64 {
   let mut z = seed
     .wrapping_mul(0x9E37_79B9_7F4A_7C15)
@@ -262,6 +273,8 @@ fn combine(vecs: &[Vector], coeff: impl Fn(usize) -> f64, dim: usize) -> Vector 
   out
 }
 
+/// The backward error of the pair $(lambda, x)$: the relative size of the
+/// smallest perturbation of $(A, B)$ making it exact.
 fn residual(
   a: &CsrMatrix,
   b: &CsrMatrix,
@@ -290,41 +303,55 @@ fn inf_norm(m: &CsrMatrix) -> f64 {
   row_sums.into_iter().fold(0.0_f64, f64::max)
 }
 
-/// $M = A - "shift" B$, factored via sparse LU. Retries with a
-/// scale-perturbed shift on singular factorization — generic only when
-/// `shift` lands exactly on an eigenvalue, which `shift = 0` does whenever
-/// the pencil has a harmonic space.
-fn factor_with_retry(a: &CsrMatrix, b: &CsrMatrix, shift: f64, a_norm: f64) -> (FaerLu, f64) {
+/// The shift `attempt` tries: the requested one first, then a geometrically
+/// growing perturbation alternating in sign, so the search stays centred on
+/// the target instead of drifting off one side.
+fn perturbed_shift(shift: f64, eps0: f64, attempt: usize) -> f64 {
+  if attempt == 0 {
+    return shift;
+  }
+  let step = eps0 * 2f64.powi(((attempt - 1) / 2) as i32);
+  if attempt % 2 == 1 {
+    shift + step
+  } else {
+    shift - step
+  }
+}
+
+/// $M = A - "shift" B$, factored via sparse LU. Retries with a perturbed shift
+/// on a singular factorization — generic only when `shift` lands exactly on an
+/// eigenvalue, which `shift = 0` does whenever the pencil has a harmonic
+/// space.
+fn factor_with_retry(
+  a: &CsrMatrix,
+  b: &CsrMatrix,
+  shift: f64,
+  a_norm: f64,
+) -> Result<(FaerLu, f64), EigenError> {
   const MAX_ATTEMPTS: usize = 16;
   let eps0 = f64::EPSILON.sqrt() * a_norm.max(1.0);
-  let mut current_shift = shift;
   for attempt in 0..MAX_ATTEMPTS {
+    let current_shift = perturbed_shift(shift, eps0, attempt);
     let m = shifted_matrix(a, b, current_shift);
     if let Some(lu) = FaerLu::try_new(m.clone()) {
-      // A merely non-singular-in-exact-arithmetic M can still be
-      // catastrophically ill-conditioned in floating point — `shift`
-      // landing so close to an eigenvalue that `sp_lu` "succeeds" but
+      // A shift landing near an eigenvalue leaves an M that factors but
       // amplifies noise into the near-null direction. The forward residual
-      // `M x - rhs` stays small even then (M nearly annihilates that
-      // direction), so it can't see the problem; round-tripping a probe
-      // vector through solve and checking it comes back unchanged can.
+      // cannot see this (M nearly annihilates that direction); a round trip
+      // can, recovering a probe to about $kappa(M) epsilon$ — so this rejects
+      // $kappa(M) gt.tilde 10^10$, past which the solve's error swamps the
+      // eigenvector it is meant to produce.
       let probe = Vector::from_iterator(
         m.nrows(),
         (0..m.nrows()).map(|i| pseudo_random(!0, i as u64)),
       );
       let rhs = &m * &probe;
       let resolved = lu.solve(&rhs);
-      let stable = (&resolved - &probe).norm() <= 1e-6 * probe.norm().max(1.0);
-      if stable {
-        return (lu, current_shift);
+      if (&resolved - &probe).norm() <= 1e-6 * probe.norm().max(1.0) {
+        return Ok((lu, current_shift));
       }
     }
-    current_shift = shift + eps0 * 2f64.powi(attempt as i32);
   }
-  panic!(
-    "sparse_shift_invert_eigen: A - shift*B remained singular after \
-     {MAX_ATTEMPTS} perturbations of shift {shift}"
-  );
+  Err(EigenError::SingularPencil { shift })
 }
 
 fn shifted_matrix(a: &CsrMatrix, b: &CsrMatrix, shift: f64) -> CsrMatrix {
@@ -371,7 +398,7 @@ mod test {
     let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
 
     for nev in 1..=n {
-      let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, nev);
+      let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, nev).unwrap();
       for k in 0..vals.len() {
         let x = vecs.column(k).into_owned();
         let residual = (&a * &x - vals[k] * (&b * &x)).norm();
@@ -392,7 +419,7 @@ mod test {
     oracle.sort_by(|x, y| x.abs().total_cmp(&y.abs()));
 
     for nev in 1..=n {
-      let (vals, _) = sparse_shift_invert_eigen(&csr(&a), &csr(&id), 0.0, nev);
+      let (vals, _) = sparse_shift_invert_eigen(&csr(&a), &csr(&id), 0.0, nev).unwrap();
       let mut got: Vec<f64> = vals.iter().copied().collect();
       let mut want = oracle[..nev].to_vec();
       got.sort_by(f64::total_cmp);
@@ -410,7 +437,7 @@ mod test {
     let a = symmetric(n, |i, j| if i == j { 2.0 * n as f64 } else { 0.5 });
     let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
 
-    let (_, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, n);
+    let (_, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, n).unwrap();
     for k in 0..vecs.ncols() {
       for l in 0..vecs.ncols() {
         let vk = vecs.column(k).into_owned();
@@ -432,7 +459,7 @@ mod test {
     // PSD but rank-deficient: the last coordinate carries no mass.
     let b = Matrix::from_fn(n, n, |i, j| if i == j && i + 1 < n { 1.0 } else { 0.0 });
 
-    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.1, n - 1);
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.1, n - 1).unwrap();
     assert_eq!(vals.len(), n - 1);
     for k in 0..vals.len() {
       assert!(vals[k].is_finite());
@@ -448,7 +475,7 @@ mod test {
   fn solves_the_scalar_pencil() {
     let a = Matrix::from_element(1, 1, 3.0);
     let b = Matrix::from_element(1, 1, 4.0);
-    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 3);
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 3).unwrap();
     assert_eq!(vals.len(), 1);
     assert!((vals[0] - 3.0 / 4.0).abs() < 1e-9);
     let x: Vector = vecs.column(0).into_owned();
@@ -458,9 +485,21 @@ mod test {
     );
     assert!((&a * &x - vals[0] * (&b * &x)).norm() < 1e-9);
 
-    let (vals0, vecs0) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 0);
+    let (vals0, vecs0) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 0).unwrap();
     assert_eq!(vals0.len(), 0);
     assert_eq!(vecs0.ncols(), 0);
+  }
+
+  /// A pencil with no finite eigenvalue at all ($B = 0$) is reported, not
+  /// panicked on.
+  #[test]
+  fn reports_a_pencil_without_finite_eigenvalues() {
+    let a = Matrix::identity(4, 4);
+    let b = Matrix::zeros(4, 4);
+    assert_eq!(
+      sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, 2),
+      Err(super::EigenError::NoFiniteEigenvalue)
+    );
   }
 
   /// A degenerate cluster of multiplicity `m` sitting exactly at the shift —
@@ -472,9 +511,8 @@ mod test {
     let m = 3;
     let rest = 4;
     let n = m + rest;
-    // B = I. A has an m-fold zero eigenvalue (the first m basis vectors) and
-    // `rest` nonzero eigenvalues elsewhere, mixed by a fixed orthonormal-ish
-    // change of basis so the cluster isn't axis-aligned with the seed.
+    // B = I. A has an m-fold zero eigenvalue and `rest` nonzero ones, mixed by
+    // a fixed change of basis so the cluster isn't axis-aligned with the seed.
     let b = Matrix::identity(n, n);
     let diag = Matrix::from_fn(n, n, |i, j| {
       if i != j || i < m {
@@ -483,14 +521,12 @@ mod test {
         (i - m + 1) as f64
       }
     });
-    // A small fixed rotation mixing coordinates, so the zero-eigenspace is
-    // not simply the first m standard basis vectors.
     let rot = Matrix::from_fn(n, n, |i, j| ((i * 5 + j * 3 + 1) % 7) as f64 - 3.0);
     let rot = rot.clone() + rot.transpose() + Matrix::identity(n, n) * (2.0 * n as f64);
     let a = &rot * &diag * &rot.transpose();
     let a = (&a + a.transpose()) * 0.5;
 
-    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, m);
+    let (vals, vecs) = sparse_shift_invert_eigen(&csr(&a), &csr(&b), 0.0, m).unwrap();
     assert_eq!(vals.len(), m);
     for &v in vals.iter() {
       assert!(v.abs() < 1e-6, "expected a near-zero eigenvalue, got {v}");
@@ -500,9 +536,8 @@ mod test {
       let residual = (&a * &x - vals[k] * &x).norm();
       assert!(residual < 1e-6, "k={k} residual={residual:e}");
     }
-    // The m recovered eigenvectors are linearly independent (B-orthonormal),
-    // so together they span the whole zero-eigenspace rather than repeating
-    // one direction.
+    // The m recovered eigenvectors are B-orthonormal, hence independent, hence
+    // span the whole zero-eigenspace rather than repeating one direction.
     let gram = vecs.transpose() * &vecs;
     let dev = (&gram - Matrix::identity(m, m)).norm();
     assert!(
@@ -535,7 +570,7 @@ mod test {
     }
     let b = CsrMatrix::from(&ident);
 
-    let (vals, vecs) = sparse_shift_invert_eigen(&a, &b, 0.0, nev);
+    let (vals, vecs) = sparse_shift_invert_eigen(&a, &b, 0.0, nev).unwrap();
     assert_eq!(vals.len(), nev);
     for k in 0..nev {
       let x = vecs.column(k).into_owned();

--- a/crates/common/src/linalg/faer.rs
+++ b/crates/common/src/linalg/faer.rs
@@ -1,6 +1,6 @@
 use faer::linalg::solvers::Solve;
 
-use super::nalgebra::{CscMatrix, CsrMatrix, Matrix, Vector};
+use super::nalgebra::{CscMatrix, CsrMatrix, Vector};
 
 pub fn faervec2navec(faer: &faer::Mat<f64>) -> Vector {
   assert_eq!(faer.ncols(), 1);
@@ -38,147 +38,19 @@ pub struct FaerLu {
 }
 impl FaerLu {
   pub fn new(a: CsrMatrix) -> Self {
-    let raw = nalgebra2faer(a).sp_lu().unwrap();
-    Self { raw }
+    Self::try_new(a).expect("sparse LU factorization failed")
+  }
+  /// Fallible variant of [`FaerLu::new`], for callers that can retry on a
+  /// factorization failure (e.g. a shift landing exactly on an eigenvalue).
+  pub fn try_new(a: CsrMatrix) -> Option<Self> {
+    let raw = nalgebra2faer(a).sp_lu().ok()?;
+    Some(Self { raw })
   }
   pub fn solve(&self, b: &Vector) -> Vector {
     let b = faer::Col::from_fn(b.nrows(), |i| b[i]);
     let x = self.raw.solve(b);
     Vector::from_iterator(x.nrows(), x.iter().copied())
   }
-}
-
-/// The generalized eigenproblem $A x = lambda B x$, solved for the
-/// `neigenvalues` eigenpairs whose eigenvalue is nearest $0$.
-///
-/// A dense QZ factorization (`faer`'s `generalized_eigen`) of the pencil
-/// $(A, B)$. It is deliberately the crudest correct method: it forms the whole
-/// spectrum and keeps the few wanted pairs, so it is $O(n^3)$ time and $O(n^2)$
-/// memory. That is right only while the meshes are small — the scaling
-/// endpoint is a sparse shift-invert Lanczos, which this does not attempt.
-///
-/// QZ carries no definiteness assumption, so it is correct on the mixed
-/// Hodge–Laplace pencil where $B$ is singular *and* indefinite: a null vector
-/// of $B$ is returned as an infinite eigenvalue ($beta = 0$), which sorts to
-/// the far end and is discarded by the nearest-to-$0$ selection. The pencils
-/// here are symmetric with real spectrum; the imaginary parts QZ returns are
-/// rounding noise and are dropped.
-pub fn faer_ghiep(lhs: &CsrMatrix, rhs: &CsrMatrix, neigenvalues: usize) -> (Vector, Matrix) {
-  let n = lhs.nrows();
-  let lhs_dense = Matrix::from(lhs);
-  let rhs_dense = Matrix::from(rhs);
-
-  // faer's dense QZ mis-sizes its workspace for $n <= 1$, but the generalized
-  // eigenproblem is trivial at that size: the $1 times 1$ pencil $(a, b)$ has the
-  // single eigenvalue $a / b$ with $B$-normalized eigenvector $1 / sqrt(b)$, and
-  // the empty pencil has none. This is the base case that lets the
-  // $0$-dimensional manifold (a point, on which the Hodge Laplacian is the zero
-  // operator) solve rather than crash.
-  if n <= 1 {
-    let count = neigenvalues.min(n);
-    let eigenvals = Vector::from_iterator(
-      count,
-      (0..count).map(|i| lhs_dense[(i, i)] / rhs_dense[(i, i)]),
-    );
-    let eigenvecs = Matrix::from_fn(n, count, |i, _| 1.0 / rhs_dense[(i, i)].sqrt());
-    return (eigenvals, eigenvecs);
-  }
-
-  let a = faer::Mat::from_fn(n, n, |i, j| lhs_dense[(i, j)]);
-  let b = faer::Mat::from_fn(n, n, |i, j| rhs_dense[(i, j)]);
-
-  let gevd = a.generalized_eigen(&b).unwrap();
-  let alpha = gevd.S_a().column_vector();
-  let beta = gevd.S_b().column_vector();
-  let vecs = gevd.U();
-
-  // $lambda = alpha / beta$; an infinite eigenvalue ($beta = 0$) gets the key
-  // $+oo$ so it sorts last and never enters the selection.
-  let mut order: Vec<usize> = (0..n).collect();
-  let key = |i: usize| {
-    let lambda = *alpha.get(i) / *beta.get(i);
-    if lambda.norm().is_finite() {
-      lambda.norm()
-    } else {
-      f64::INFINITY
-    }
-  };
-  order.sort_by(|&i, &j| key(i).total_cmp(&key(j)));
-  order.truncate(neigenvalues);
-
-  let eigenvals = Vector::from_iterator(
-    order.len(),
-    order.iter().map(|&i| (*alpha.get(i) / *beta.get(i)).re),
-  );
-  let eigenvecs = Matrix::from_fn(n, order.len(), |i, k| vecs.get(i, order[k]).re);
-  (eigenvals, eigenvecs)
-}
-
-/// The generalized symmetric-definite eigenproblem $A x = lambda B x$, with $A$
-/// symmetric and $B$ symmetric *positive definite*, solved for the
-/// `neigenvalues` algebraically smallest pairs. Eigenvalues are returned in
-/// ascending order; eigenvectors are $B$-orthonormal.
-///
-/// Where [`faer_ghiep`] carries no definiteness assumption and pays for it with
-/// a nonsymmetric QZ, this exploits the structure of the elliptic pencil (the
-/// FE stiffness against an SPD mass matrix). A Cholesky factor $B = L L^top$
-/// reduces the pencil to the standard self-adjoint problem $C y = lambda y$ with
-/// $C = L^(-1) A L^(-top)$, whose spectrum is real, whose solver is a symmetric
-/// tridiagonal QR — an order of magnitude cheaper than QZ and parallel — and
-/// whose eigenvectors back-transform as $x = L^(-top) y$.
-///
-/// Still dense: it forms the whole spectrum and keeps the smallest
-/// `neigenvalues`, so $O(n^3)$ time and $O(n^2)$ memory, right only while the
-/// meshes are small. The scaling endpoint is a sparse shift-invert Lanczos,
-/// which this does not attempt. $B$ *must* be positive definite; on the
-/// singular, indefinite pencil of the mixed formulation, use [`faer_ghiep`].
-pub fn faer_gsdiep(lhs: &CsrMatrix, rhs: &CsrMatrix, neigenvalues: usize) -> (Vector, Matrix) {
-  let n = lhs.nrows();
-  let lhs_dense = Matrix::from(lhs);
-  let rhs_dense = Matrix::from(rhs);
-  let count = neigenvalues.min(n);
-
-  // The $1 times 1$ (and empty) base case, mirroring faer_ghiep: the pencil
-  // $(a, b)$ has the single eigenvalue $a / b$ with $B$-normalized eigenvector
-  // $1 / sqrt(b)$. This keeps the $0$-manifold total rather than tripping the
-  // Cholesky/EVD on a degenerate size.
-  if n <= 1 {
-    let eigenvals = Vector::from_iterator(
-      count,
-      (0..count).map(|i| lhs_dense[(i, i)] / rhs_dense[(i, i)]),
-    );
-    let eigenvecs = Matrix::from_fn(n, count, |i, _| 1.0 / rhs_dense[(i, i)].sqrt());
-    return (eigenvals, eigenvecs);
-  }
-
-  let a = faer::Mat::from_fn(n, n, |i, j| lhs_dense[(i, j)]);
-  let b = faer::Mat::from_fn(n, n, |i, j| rhs_dense[(i, j)]);
-
-  let l = b
-    .llt(faer::Side::Lower)
-    .expect("B is not positive definite; use faer_ghiep on an indefinite pencil")
-    .L()
-    .to_owned();
-
-  // $C = L^(-1) A L^(-top)$ via two lower-triangular solves. With $A$ symmetric,
-  // $W = L^(-1) A$ has $W^top = A L^(-top)$, so $L^(-1) W^top = C$ is symmetric;
-  // the EVD reads only its lower triangle, absorbing the rounding asymmetry.
-  let mut w = a;
-  l.solve_lower_triangular_in_place(w.as_mut());
-  let mut c = w.transpose().to_owned();
-  l.solve_lower_triangular_in_place(c.as_mut());
-
-  let eig = c.self_adjoint_eigen(faer::Side::Lower).unwrap();
-  let vals = eig.S().column_vector();
-  let y = eig.U();
-
-  // The smallest `count` are the leading columns; back-transform $x = L^(-top) y$.
-  let mut x = faer::Mat::from_fn(n, count, |i, k| *y.get(i, k));
-  l.transpose().solve_upper_triangular_in_place(x.as_mut());
-
-  let eigenvals = Vector::from_iterator(count, (0..count).map(|i| *vals.get(i)));
-  let eigenvecs = Matrix::from_fn(n, count, |i, k| *x.get(i, k));
-  (eigenvals, eigenvecs)
 }
 
 pub struct FaerCholesky {
@@ -194,133 +66,5 @@ impl FaerCholesky {
     let b = faer::Col::from_fn(b.nrows(), |i| b[i]);
     let x = self.raw.solve(b);
     Vector::from_iterator(x.nrows(), x.iter().copied())
-  }
-}
-
-#[cfg(test)]
-mod test {
-  use super::{faer_ghiep, faer_gsdiep, Matrix, Vector};
-
-  fn symmetric(n: usize, f: impl Fn(usize, usize) -> f64) -> Matrix {
-    Matrix::from_fn(n, n, |i, j| f(i.min(j), i.max(j)))
-  }
-
-  /// Every returned pair solves the pencil: $A x = lambda B x$.
-  #[test]
-  fn ghiep_pairs_solve_the_pencil() {
-    let n = 6;
-    let a = symmetric(n, |i, j| ((i * 7 + j * 3) % 11) as f64 - 5.0);
-    // SPD: diagonally dominant with a positive diagonal.
-    let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
-
-    for nev in 1..=n {
-      let (vals, vecs) = faer_ghiep(&(&a).into(), &(&b).into(), nev);
-      for k in 0..vals.len() {
-        let x = vecs.column(k).into_owned();
-        let residual = (&a * &x - vals[k] * (&b * &x)).norm();
-        assert!(residual < 1e-9, "nev={nev} k={k} residual={residual:e}");
-      }
-    }
-  }
-
-  /// With $B = I$ the pencil is the standard symmetric eigenproblem, so the
-  /// eigenvalues nearest $0$ must match a dense symmetric EVD oracle.
-  #[test]
-  fn ghiep_matches_symmetric_evd_oracle() {
-    let n = 7;
-    let a = symmetric(n, |i, j| ((i * 5 + j * 2) % 13) as f64 - 6.0);
-    let id = Matrix::identity(n, n);
-
-    let mut oracle: Vec<f64> = a.clone().symmetric_eigenvalues().iter().copied().collect();
-    oracle.sort_by(|x, y| x.abs().total_cmp(&y.abs()));
-
-    for nev in 1..=n {
-      let (vals, _) = faer_ghiep(&(&a).into(), &(&id).into(), nev);
-      let mut got: Vec<f64> = vals.iter().copied().collect();
-      let mut want = oracle[..nev].to_vec();
-      got.sort_by(f64::total_cmp);
-      want.sort_by(f64::total_cmp);
-      for (g, w) in got.iter().zip(&want) {
-        assert!((g - w).abs() < 1e-9, "nev={nev}: got {g} want {w}");
-      }
-    }
-  }
-
-  /// The $1 times 1$ base case (the $0$-manifold's Hodge-Laplace pencil), where
-  /// faer's dense QZ mis-sizes its workspace: the lone eigenvalue is $a / b$ with
-  /// a $B$-normalized eigenvector, and it still solves the pencil.
-  #[test]
-  fn ghiep_solves_the_scalar_pencil() {
-    let a = Matrix::from_element(1, 1, 3.0);
-    let b = Matrix::from_element(1, 1, 4.0);
-    let (vals, vecs) = faer_ghiep(&(&a).into(), &(&b).into(), 3);
-    assert_eq!(vals.len(), 1);
-    assert!((vals[0] - 3.0 / 4.0).abs() < 1e-12);
-    let x: Vector = vecs.column(0).into_owned();
-    assert!(
-      (x.dot(&(&b * &x)) - 1.0).abs() < 1e-12,
-      "eigenvector is B-normalized"
-    );
-    assert!((&a * &x - vals[0] * (&b * &x)).norm() < 1e-12);
-  }
-
-  /// The symmetric-definite solver agrees with the general QZ on a definite
-  /// pencil — same smallest eigenvalues — and every returned pair solves
-  /// $A x = lambda B x$ with a $B$-orthonormal eigenvector.
-  #[test]
-  fn gsdiep_matches_ghiep_on_definite_pencil() {
-    let n = 6;
-    // The elliptic regime gsdiep is for: an SPD $A$ (positive spectrum), where
-    // "algebraically smallest" and "smallest magnitude" coincide, so gsdiep's
-    // ascending selection matches ghiep's magnitude selection. On an indefinite
-    // $A$ the two conventions legitimately diverge and are not meant to agree.
-    let a = symmetric(n, |i, j| if i == j { 2.0 * n as f64 } else { 0.5 });
-    // SPD: diagonally dominant with a positive diagonal.
-    let b = symmetric(n, |i, j| if i == j { n as f64 } else { 0.3 });
-
-    for nev in 1..=n {
-      let (vals, vecs) = faer_gsdiep(&(&a).into(), &(&b).into(), nev);
-      let (want, _) = faer_ghiep(&(&a).into(), &(&b).into(), nev);
-
-      let mut got: Vec<f64> = vals.iter().copied().collect();
-      let mut want: Vec<f64> = want.iter().copied().collect();
-      got.sort_by(f64::total_cmp);
-      want.sort_by(f64::total_cmp);
-      for (g, w) in got.iter().zip(&want) {
-        assert!((g - w).abs() < 1e-9, "nev={nev}: got {g} want {w}");
-      }
-
-      for k in 0..vals.len() {
-        let x = vecs.column(k).into_owned();
-        let residual = (&a * &x - vals[k] * (&b * &x)).norm();
-        assert!(residual < 1e-9, "nev={nev} k={k} residual={residual:e}");
-        let bnorm = x.dot(&(&b * &x));
-        assert!(
-          (bnorm - 1.0).abs() < 1e-9,
-          "nev={nev} k={k} not B-normalized"
-        );
-      }
-    }
-  }
-
-  /// A singular, indefinite $B$ (the mixed-formulation regime): a null
-  /// direction of $B$ is an infinite eigenvalue, excluded by the nearest-to-$0$
-  /// selection, and the finite pairs it does return still solve the pencil.
-  #[test]
-  fn ghiep_excludes_infinite_eigenvalues() {
-    let n = 5;
-    let a = symmetric(n, |i, j| ((i * 3 + j * 7) % 11) as f64 - 5.0);
-    // PSD but rank-deficient: the last coordinate carries no mass, so $B$ has a
-    // one-dimensional kernel and the pencil has an eigenvalue at infinity.
-    let b = Matrix::from_fn(n, n, |i, j| if i == j && i + 1 < n { 1.0 } else { 0.0 });
-
-    let (vals, vecs) = faer_ghiep(&(&a).into(), &(&b).into(), n - 1);
-    assert_eq!(vals.len(), n - 1);
-    for k in 0..vals.len() {
-      assert!(vals[k].is_finite());
-      let x: Vector = vecs.column(k).into_owned();
-      let residual = (&a * &x - vals[k] * (&b * &x)).norm();
-      assert!(residual < 1e-9, "k={k} residual={residual:e}");
-    }
   }
 }

--- a/crates/formoniq/examples/hodge_laplace_evp.rs
+++ b/crates/formoniq/examples/hodge_laplace_evp.rs
@@ -70,12 +70,10 @@ fn box_sweep() {
           "r", "ncells"
         );
 
-        // Every grade solves a dense generalized eigenproblem, $O(N^3)$ in the
-        // mixed-system size $N$, so refine only while that stays affordable and
-        // stop at the first level that would exceed the budget. In 3D this leaves
-        // just a couple of levels; the source example, on the sparse LU, carries
-        // the finer convergence story.
-        const MAX_DOFS: usize = 1200;
+        // The eigensolve is a sparse shift-invert Lanczos, so the budget is set
+        // by wall-clock patience for a hand-run sweep, not by a dense O(N^3)
+        // ceiling.
+        const MAX_DOFS: usize = 20_000;
 
         // History of the lowest eigenvalues per level, for the three-point
         // Richardson estimate of each eigenvalue's convergence order.

--- a/crates/formoniq/examples/hodge_laplace_evp.rs
+++ b/crates/formoniq/examples/hodge_laplace_evp.rs
@@ -92,7 +92,7 @@ fn box_sweep() {
             } else {
               0
             };
-          // Stop once the dense solve would exceed the budget, or once refinement
+          // Stop once the solve would exceed the budget, or once refinement
           // no longer grows the mesh — a 0-manifold is a single point and does not
           // subdivide, so it has exactly one level.
           if !history.is_empty() && (ndofs > MAX_DOFS || ndofs == prev_ndofs) {
@@ -101,17 +101,13 @@ fn box_sweep() {
           prev_ndofs = ndofs;
 
           let (eigenvals, _, _) = if relative {
-            hodge_laplace::solve_hodge_laplace_evp(&whitney.relative(), grade, neigen)
+            hodge_laplace::solve_hodge_laplace_evp(&whitney.relative(), grade, neigen).unwrap()
           } else {
-            hodge_laplace::solve_hodge_laplace_evp(&whitney, grade, neigen)
+            hodge_laplace::solve_hodge_laplace_evp(&whitney, grade, neigen).unwrap()
           };
-          // The coarsest levels can carry fewer DOFs than the requested count; the
-          // eigensolver pads the rest with non-finite values.
-          let eigenvals: Vec<f64> = eigenvals
-            .iter()
-            .copied()
-            .filter(|x| x.is_finite())
-            .collect();
+          // The coarsest levels can carry fewer DOFs than the requested count,
+          // and then the eigensolver returns fewer pairs.
+          let eigenvals: Vec<f64> = eigenvals.iter().copied().collect();
 
           // Richardson: with three successive levels the ratio of consecutive
           // differences estimates the order without knowing the exact eigenvalue.
@@ -171,8 +167,11 @@ fn interactive_mesh() -> Result<(), Box<dyn std::error::Error>> {
   let grade: usize = prompt("Enter exterior grade.")?.parse()?;
   let neigen: usize = prompt("Enter number of eigenvalues.")?.parse()?;
 
-  let (eigenvals, _, _) =
-    hodge_laplace::solve_hodge_laplace_evp(&WhitneyComplex::new(&topology, &metric), grade, neigen);
+  let (eigenvals, _, _) = hodge_laplace::solve_hodge_laplace_evp(
+    &WhitneyComplex::new(&topology, &metric),
+    grade,
+    neigen,
+  )?;
   for (i, &lambda) in eigenvals.iter().enumerate() {
     println!("eigenvalue {i}: {lambda:.4}");
   }

--- a/crates/formoniq/examples/hodge_laplace_source.rs
+++ b/crates/formoniq/examples/hodge_laplace_source.rs
@@ -91,10 +91,10 @@ fn main() {
           // boundary-vanishing cochains; the solver is one piece of code over both.
           let (_, galsol, _) = match bc {
             BoundaryCondition::Absolute => {
-              hodge_laplace::solve_hodge_laplace_source(&whitney, source, grade)
+              hodge_laplace::solve_hodge_laplace_source(&whitney, source, grade).unwrap()
             }
             BoundaryCondition::Relative => {
-              hodge_laplace::solve_hodge_laplace_source(&whitney.relative(), source, grade)
+              hodge_laplace::solve_hodge_laplace_source(&whitney.relative(), source, grade).unwrap()
             }
           };
 

--- a/crates/formoniq/examples/hodge_laplace_source.rs
+++ b/crates/formoniq/examples/hodge_laplace_source.rs
@@ -56,13 +56,10 @@ fn main() {
         );
 
         // Whenever the harmonic space is nontrivial, fixing the harmonic part
-        // runs a dense generalized eigensolve, $O(N^3)$ in the mixed-system size
-        // $N = dim cal(W) Lambda^k + dim cal(W) Lambda^(k-1)$ at this grade. That
-        // cost, not the dimension, sets the refinement budget: absolute hits it
-        // at grade $0$ (smallest system), relative at top grade (largest), so a
-        // per-dimension cap would misjudge both. Stop at the first level over
-        // budget. This is the same rule the eigenvalue example uses.
-        const MAX_DOFS: usize = 1200;
+        // runs a sparse shift-invert Lanczos solve for exactly the harmonic
+        // dimension's worth of eigenpairs, so the budget here is wall-clock
+        // patience for a hand-run sweep, not a dense O(N^3) ceiling.
+        const MAX_DOFS: usize = 20_000;
 
         let mut errors_l2 = Vec::new();
         let mut errors_hd = Vec::new();

--- a/crates/formoniq/src/problems/hodge_laplace.rs
+++ b/crates/formoniq/src/problems/hodge_laplace.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 
 use {
-  common::linalg::{eigen::sparse_shift_invert_eigen, faer::FaerLu},
+  common::linalg::{
+    eigen::{sparse_shift_invert_eigen, EigenError},
+    faer::FaerLu,
+  },
   ddf::cochain::Cochain,
   exterior::ExteriorGrade,
 };
@@ -24,14 +27,17 @@ use std::mem;
 /// so the caller is oblivious to the boundary condition. `p` is the harmonic
 /// component of $u$, fixed to zero against the harmonic space $cal(H)^k$.
 ///
+/// Fails only where [`solve_hodge_laplace_harmonics`] does: the harmonic basis
+/// is an eigensolve.
+///
 /// [`WhitneyComplex`]: crate::whitney_complex::WhitneyComplex
 /// [`RelativeWhitneyComplex`]: crate::whitney_complex::RelativeWhitneyComplex
 pub fn solve_hodge_laplace_source<C: HilbertComplex>(
   complex: &C,
   source_galvec: GalVec,
   grade: ExteriorGrade,
-) -> (Cochain, Cochain, Cochain) {
-  let harmonics = solve_hodge_laplace_harmonics(complex, grade);
+) -> Result<(Cochain, Cochain, Cochain), EigenError> {
+  let harmonics = solve_hodge_laplace_harmonics(complex, grade)?;
 
   let galmats = MixedGalmats::compute(complex, grade);
 
@@ -98,13 +104,13 @@ pub fn solve_hodge_laplace_source<C: HilbertComplex>(
   // `p` is the coefficient vector against the harmonic basis (length $b_k$), a
   // Lagrange multiplier — not a cochain in $u$-space, so it is not extended.
   let p = Cochain::new(grade, p_coeffs);
-  (sigma, u, p)
+  Ok((sigma, u, p))
 }
 
 pub fn solve_hodge_laplace_harmonics<C: HilbertComplex>(
   complex: &C,
   grade: ExteriorGrade,
-) -> Matrix {
+) -> Result<Matrix, EigenError> {
   // The dimension of the harmonic space is the Betti number $b_k$ (Hodge
   // theorem: $cal(H)^k tilde.equ H^k tilde.equ H_k$), an exact topological
   // invariant of the complex — not a number the caller has to know. Absolute
@@ -113,19 +119,22 @@ pub fn solve_hodge_laplace_harmonics<C: HilbertComplex>(
   let homology_dim = complex.harmonic_dim(grade);
   if homology_dim == 0 {
     let nwhitneys = complex.ndofs(grade);
-    return Matrix::zeros(nwhitneys, 0);
+    return Ok(Matrix::zeros(nwhitneys, 0));
   }
 
-  let (eigenvals, _, harmonics) = solve_hodge_laplace_evp(complex, grade, homology_dim);
+  let (eigenvals, _, harmonics) = solve_hodge_laplace_evp(complex, grade, homology_dim)?;
   assert!(eigenvals.iter().all(|&eigenval| eigenval <= 1e-12));
-  harmonics
+  Ok(harmonics)
 }
 
+/// The `neigenvalues` eigenpairs of the mixed Hodge-Laplace pencil nearest
+/// $0$, as $(lambda, sigma, u)$. Fewer, on a complex whose DOFs cannot support
+/// that many.
 pub fn solve_hodge_laplace_evp<C: HilbertComplex>(
   complex: &C,
   grade: ExteriorGrade,
   neigenvalues: usize,
-) -> (Vector, Matrix, Matrix) {
+) -> Result<(Vector, Matrix, Matrix), EigenError> {
   let galmats = MixedGalmats::compute(complex, grade);
 
   let lhs = galmats.mixed_hodge_laplacian();
@@ -140,11 +149,11 @@ pub fn solve_hodge_laplace_evp<C: HilbertComplex>(
   }
 
   let (eigenvals, eigenvectors) =
-    sparse_shift_invert_eigen(&(&lhs).into(), &(&rhs).into(), 0.0, neigenvalues);
+    sparse_shift_invert_eigen(&(&lhs).into(), &(&rhs).into(), 0.0, neigenvalues)?;
 
   let eigen_sigmas = eigenvectors.rows(0, sigma_len).into_owned();
   let eigen_us = eigenvectors.rows(sigma_len, u_len).into_owned();
-  (eigenvals, eigen_sigmas, eigen_us)
+  Ok((eigenvals, eigen_sigmas, eigen_us))
 }
 
 pub struct MixedGalmats {

--- a/crates/formoniq/src/problems/hodge_laplace.rs
+++ b/crates/formoniq/src/problems/hodge_laplace.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use {
-  common::linalg::faer::{faer_ghiep, faer_gsdiep, FaerLu},
+  common::linalg::{eigen::sparse_shift_invert_eigen, faer::FaerLu},
   ddf::cochain::Cochain,
   exterior::ExteriorGrade,
 };
@@ -139,17 +139,8 @@ pub fn solve_hodge_laplace_evp<C: HilbertComplex>(
     rhs.push(r, c, v);
   }
 
-  // At grade 0 the $sigma$ block is empty, so the pencil is $codif dif$ against
-  // the mass matrix — symmetric positive-(semi)definite, admitting the cheaper
-  // Cholesky-reduction path. For $k > 0$ the mixed KKT pencil is symmetric
-  // indefinite and needs the general solver. This dispatches on the assembled
-  // shape ($sigma_"len" = 0$), not on the grade — the definiteness is what earns
-  // the fast path.
-  let (eigenvals, eigenvectors) = if sigma_len == 0 {
-    faer_gsdiep(&(&lhs).into(), &(&rhs).into(), neigenvalues)
-  } else {
-    faer_ghiep(&(&lhs).into(), &(&rhs).into(), neigenvalues)
-  };
+  let (eigenvals, eigenvectors) =
+    sparse_shift_invert_eigen(&(&lhs).into(), &(&rhs).into(), 0.0, neigenvalues);
 
   let eigen_sigmas = eigenvectors.rows(0, sigma_len).into_owned();
   let eigen_us = eigenvectors.rows(sigma_len, u_len).into_owned();

--- a/crates/formoniq/src/problems/maxwell.rs
+++ b/crates/formoniq/src/problems/maxwell.rs
@@ -48,6 +48,7 @@
 use crate::whitney_complex::WhitneyComplex;
 
 use common::linalg::{
+  eigen::{sparse_shift_invert_eigen, EigenError},
   faer::FaerCholesky,
   nalgebra::{bilinear_form_sparse, quadratic_form_sparse, CsrMatrix, Vector},
 };
@@ -399,18 +400,15 @@ pub fn solve_maxwell_curl_curl(
 /// extended by zero from the relative complex onto the full mesh.
 ///
 /// The frequency-domain counterpart of the time-domain solvers above, built
-/// from the very same operators. Solved by [`sparse_shift_invert_eigen`], the
-/// eigenvalues nearest $0$ so as to capture the static zero modes together
-/// with the lowest resonant frequencies.
-///
-/// [`sparse_shift_invert_eigen`]: common::linalg::eigen::sparse_shift_invert_eigen
+/// from the very same operators. Solved by [`sparse_shift_invert_eigen`] for
+/// the eigenvalues nearest $0$. $ker K$ contains every discrete gradient
+/// field, so `nmodes` must exceed its dimension before a resonance appears
+/// among the modes returned.
 pub fn solve_maxwell_cavity_modes(
   fes: WhitneyComplex,
   medium: Medium,
   nmodes: usize,
-) -> (Vector, Vec<Cochain>) {
-  use common::linalg::eigen::sparse_shift_invert_eigen;
-
+) -> Result<(Vector, Vec<Cochain>), EigenError> {
   let ops = MaxwellOperators::new(&fes, medium);
   let relative = fes.relative();
   let incl = relative.inclusion(1);
@@ -418,14 +416,14 @@ pub fn solve_maxwell_cavity_modes(
   let stiffness_rel = incl.transpose() * &ops.stiffness() * &incl;
   let mass_rel = incl.transpose() * &ops.mass_e * &incl;
 
-  let (eigenvals, eigenvecs) = sparse_shift_invert_eigen(&stiffness_rel, &mass_rel, 0.0, nmodes);
+  let (eigenvals, eigenvecs) = sparse_shift_invert_eigen(&stiffness_rel, &mass_rel, 0.0, nmodes)?;
 
   let modes = eigenvecs
     .column_iter()
     .map(|c| Cochain::new(1, &incl * c.into_owned()))
     .collect();
 
-  (eigenvals, modes)
+  Ok((eigenvals, modes))
 }
 
 #[cfg(test)]

--- a/crates/formoniq/src/problems/maxwell.rs
+++ b/crates/formoniq/src/problems/maxwell.rs
@@ -399,16 +399,17 @@ pub fn solve_maxwell_curl_curl(
 /// extended by zero from the relative complex onto the full mesh.
 ///
 /// The frequency-domain counterpart of the time-domain solvers above, built
-/// from the very same operators. Solved natively by [`faer_ghiep`], a dense QZ
-/// on the generalized pencil.
+/// from the very same operators. Solved by [`sparse_shift_invert_eigen`], the
+/// eigenvalues nearest $0$ so as to capture the static zero modes together
+/// with the lowest resonant frequencies.
 ///
-/// [`faer_ghiep`]: common::linalg::faer::faer_ghiep
+/// [`sparse_shift_invert_eigen`]: common::linalg::eigen::sparse_shift_invert_eigen
 pub fn solve_maxwell_cavity_modes(
   fes: WhitneyComplex,
   medium: Medium,
   nmodes: usize,
 ) -> (Vector, Vec<Cochain>) {
-  use common::linalg::faer::faer_ghiep;
+  use common::linalg::eigen::sparse_shift_invert_eigen;
 
   let ops = MaxwellOperators::new(&fes, medium);
   let relative = fes.relative();
@@ -417,7 +418,7 @@ pub fn solve_maxwell_cavity_modes(
   let stiffness_rel = incl.transpose() * &ops.stiffness() * &incl;
   let mass_rel = incl.transpose() * &ops.mass_e * &incl;
 
-  let (eigenvals, eigenvecs) = faer_ghiep(&stiffness_rel, &mass_rel, nmodes);
+  let (eigenvals, eigenvecs) = sparse_shift_invert_eigen(&stiffness_rel, &mass_rel, 0.0, nmodes);
 
   let modes = eigenvecs
     .column_iter()

--- a/crates/studio/src/lib.rs
+++ b/crates/studio/src/lib.rs
@@ -209,7 +209,7 @@ impl MeshSource {
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum View {
   /// A single grade of the mesh's Hodge-Laplace eigenmodes. The expensive
-  /// case: each grade is a dense eigensolve, run once and memoized, so only the
+  /// case: each grade is an eigensolve, run once and memoized, so only the
   /// grade actually being viewed is ever computed.
   MeshGrade(ExteriorGrade),
   /// Every Whitney basis function of the reference triangle. Cheap to build.
@@ -256,8 +256,8 @@ fn default_selection(scene: &Scene) -> Selection {
   }
 }
 
-/// A rebuild of `T` running off the render thread, so a solve that triggers a
-/// dense eigensolve never blocks the UI. `poll` is non-blocking and yields the
+/// A rebuild of `T` running off the render thread, so a solve that triggers an
+/// eigensolve never blocks the UI. `poll` is non-blocking and yields the
 /// result exactly once, the frame it arrives.
 ///
 /// Wasm has no threads to spawn onto, so there `build` just runs eagerly and
@@ -1595,7 +1595,7 @@ impl<'a> State<'a> {
   }
 
   /// Requests that `view` be shown. A cached view (an already-solved grade)
-  /// installs instantly; an uncached one -- a grade's dense eigensolve -- runs
+  /// installs instantly; an uncached one -- a grade's eigensolve -- runs
   /// on a background thread via `gallery`, and [`Self::poll_view_load`] installs
   /// the result once it lands, so this call never blocks the UI.
   fn set_view(&mut self, view: View) {

--- a/crates/studio/src/scene.rs
+++ b/crates/studio/src/scene.rs
@@ -137,11 +137,12 @@ impl Scene {
   /// the given geometry, filed into `fields` or `line_fields` through the
   /// same [`Self::field`] dispatch a raw Whitney basis function goes
   /// through: an eigenmode and a one-hot cochain differ only in where the
-  /// cochain comes from (a dense eigensolve vs. a Kronecker delta), not in
+  /// cochain comes from (an eigensolve vs. a Kronecker delta), not in
   /// how it is reconstructed or displayed.
   ///
-  /// The eigensolve is dense ($O(n^3)$ in the DOF count), so mesh resolution
-  /// controls both fidelity and cost.
+  /// A failed eigensolve contributes no fields and is reported on stderr: an
+  /// iteration budget too small for one mesh is not a reason to take the
+  /// viewer down.
   fn eigenmode_fields(
     topology: &Complex,
     coords: &MeshCoords,
@@ -155,8 +156,14 @@ impl Scene {
     };
 
     let metric = coords.to_edge_lengths(topology);
-    let (eigenvals, _, eigenfuncs) =
-      solve_hodge_laplace_evp(&WhitneyComplex::new(topology, &metric), grade, nmodes);
+    let solved = solve_hodge_laplace_evp(&WhitneyComplex::new(topology, &metric), grade, nmodes);
+    let (eigenvals, _, eigenfuncs) = match solved {
+      Ok(solved) => solved,
+      Err(err) => {
+        eprintln!("grade {grade} eigensolve failed: {err}");
+        return;
+      }
+    };
 
     for (i, (&lambda, col)) in eigenvals.iter().zip(eigenfuncs.column_iter()).enumerate() {
       let name = format!("mode {i} (grade {grade}, lambda = {lambda:.2})");
@@ -221,8 +228,8 @@ impl Scene {
   }
 
   /// The Hodge-Laplace eigenmodes of a *single* grade on a shared surface
-  /// mesh: the fields one grade's (dense, $O(n^3)$) eigensolve contributes,
-  /// split by their render mark. The unit the gallery computes lazily and
+  /// mesh: the fields one grade's eigensolve contributes, split by their
+  /// render mark. The unit the gallery computes lazily and
   /// memoizes -- the mesh is built once and passed in, so switching grade pays
   /// only for that grade's solve, and only the first time it is viewed. The
   /// discrete spherical harmonics are one instantiation, the mesh being a
@@ -247,7 +254,7 @@ impl Scene {
   }
 
   /// The bare icosphere carrying a single constant field: the mesh of
-  /// [`Self::spherical_harmonics`] without its (dense, $O(n^3)$) eigensolve.
+  /// [`Self::spherical_harmonics`] without its eigensolve.
   /// Stands in for the real scene so the viewer can show the sphere the instant
   /// the window opens, while the solve runs in the background and swaps the
   /// actual modes in when it lands. The lone field has no eigenvalue, so it is


### PR DESCRIPTION
## Summary

- Adds `common::linalg::eigen::sparse_shift_invert_eigen`, a spectral-transformation (shift-invert) Lanczos eigensolver for the generalized pencil `A x = λ B x` with `A`, `B` symmetric and `B` PSD (possibly singular). Block-started with block size `k` so a degenerate eigenvalue of multiplicity up to `k` — the harmonic space at `shift = 0` is exactly this case — is resolved in full rather than collapsed onto one direction. Thick-restarted by re-seeding from the best Ritz vectors found so far, with full reorthogonalization throughout.
- Deletes the dense `faer_ghiep`/`faer_gsdiep` (`O(N^3)` time, `O(N^2)` memory, forming the whole spectrum to keep a handful of eigenpairs) and the `sigma_len == 0` dispatch that picked between them.
- `solve_hodge_laplace_evp` and `solve_maxwell_cavity_modes` now call the new solver unconditionally.
- Raises `MAX_DOFS` in `hodge_laplace_evp.rs` and `hodge_laplace_source.rs` from 1200 to 20,000, since refinement is no longer bounded by a dense cubic cost.

## Test plan

- [x] `cargo test --workspace` (7 new law tests in `eigen.rs`: pencil residuals, SPD-oracle match, B-orthonormality, singular-B null-space exclusion, degenerate-cluster resolution at the shift, and a 3000×3000 sparse case dense QZ has no business reaching)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all` clean
- [x] `cargo doc --workspace --no-deps` clean
- [x] `cargo run --release --example hodge_laplace_evp` — eigenvalues match expected multiplicities/Betti numbers and converge at the expected `O(h^2)` rate through 3D at the raised refinement budget
- [x] `cargo run --release --example hodge_laplace_source` — L2/H(dif) errors converge at the expected `O(h)` rate

closes #99 

🤖 Generated with [Claude Code](https://claude.com/claude-code)