### PR TITLE
studio: add menu bar and expose study parameters in the inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "console_log",
  "coorder",
  "derham",
+ "directories",
  "egui",
  "egui-file-dialog",
  "egui-wgpu",

--- a/crates/studio/CLAUDE.md
+++ b/crates/studio/CLAUDE.md
@@ -191,6 +191,20 @@ they bind the same way the parent's invariants do:
   costs a branch below the model — a setting naming an item drops it from the
   draw list, and one naming a deformation the items ride is a material at zero,
   the shape bloom's "off" already has.
+
+  What builds the object and what draws it are the two sidebars, and they keep
+  the two questions apart: the **browser** picks the point in `MeshSource ×
+  Study` — which mesh, which computation — and the **inspector** edits the
+  parameters of the study picked there and the display of the two objects it
+  produced. `Study`'s variant parameters (the eigenmode grade and count, a
+  trajectory's sampling) are the inspector's, not the browser's, because they
+  are knobs *on* the chosen study rather than the choice of it; an edit that
+  drives a re-solve commits on release, not mid-drag, so the background solve
+  fires once. What belongs to **neither** object — reading and writing files,
+  and the view shell itself (which sidebars show, the projection, the light
+  ladder, re-framing the camera) — is a **menu bar**, the conventional home a
+  reader reaches for these by reflex, and the one place a command that is not a
+  property of the mesh or the field is allowed to live.
 - **The renderer sees baked geometry and explicit time, and nothing else.** No
   FEEC types, no clock, no window, no surface. Time is an argument, so the
   interactive loop passes wall-clock seconds and an exporter passes the instant

--- a/crates/studio/Cargo.toml
+++ b/crates/studio/Cargo.toml
@@ -68,6 +68,10 @@ env_logger = "0.11.11"
 egui-file-dialog = "0.14.1"
 clap = { version = "4.6.2", features = ["derive"] }
 image = { version = "0.25.10", default-features = false, features = ["png"] }
+# The per-user config directory the one-time welcome's marker file lives in.
+# Pure Rust and already in the tree via `egui-file-dialog`; the cross-platform
+# path logic is not worth reimplementing by hand from `$HOME`.
+directories = "6.0.0"
 
 # Web-only: the wasm entry point, the async bridge for surface creation, the DOM
 # handles for mounting the canvas, and the panic/log plumbing that routes into
@@ -86,6 +90,9 @@ web-sys = { version = "0.3.77", features = [
   "Window",
   "Element",
   "HtmlCanvasElement",
+  # The one-time welcome's persistence: the browser has no filesystem for a
+  # marker file, so the dismissed flag lives in `localStorage` instead.
+  "Storage",
   # The solve worker: the viewer's one expensive call runs here rather than on
   # the main thread, so the tab keeps rendering while a study solves.
   "Worker",

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -135,6 +135,12 @@ pub(crate) struct State {
   /// looked for rather than about the object.
   post: crate::ui::Post,
 
+  /// Whether the one-time welcome modal is still up. Seeded from the persisted
+  /// first-run marker (`welcome::should_show`), cleared -- and the marker
+  /// written -- the frame the reader dismisses it. Purely a viewer concern, so
+  /// it lives here beside the other shell state.
+  show_welcome: bool,
+
   /// The standing wave's transport clock: the elapsed animation time the
   /// renderer is handed each frame, pausable from the transport bar and reset
   /// whenever the field changes so a newly selected mode starts at its crest.
@@ -312,6 +318,7 @@ impl State {
       },
       sidebars: crate::ui::Sidebars::default(),
       post: crate::ui::Post::default(),
+      show_welcome: crate::welcome::should_show(),
       drag: None,
       cursor: None,
       last_mouse_pos: None,
@@ -999,9 +1006,37 @@ impl State {
     #[cfg(not(target_arch = "wasm32"))]
     let export_dialog = &mut self.export_dialog;
 
+    // The one-time welcome, drawn here rather than in the pure panel: it is
+    // stateful (dismissing it writes the persisted marker) and platform-shaped,
+    // like the file dialogs above. Read the flag before the closure and report
+    // the dismissal back through a local, since the closure cannot touch `self`
+    // while `model` borrows it.
+    let show_welcome = self.show_welcome;
+    let mut welcome_dismissed = false;
+
     let mut response = None;
     let full_output = ctx.run_ui(raw_input, |ui| {
       response = Some(crate::ui::panel(ui, &model));
+
+      // A modal, so the greeting sits over the whole shell and takes the first
+      // interaction: a backdrop click, Escape or the button all dismiss it.
+      if show_welcome {
+        let modal = egui::Modal::new(egui::Id::new("welcome")).show(ui.ctx(), |ui| {
+          ui.set_max_width(430.0);
+          ui.heading(crate::welcome::TITLE);
+          ui.add_space(8.0);
+          ui.label(crate::welcome::message());
+          ui.add_space(12.0);
+          ui.vertical_centered(|ui| {
+            if ui.button("Get started").clicked() {
+              ui.close();
+            }
+          });
+        });
+        if modal.should_close() {
+          welcome_dismissed = true;
+        }
+      }
 
       // Both browsers draw as their own windows and open on the panel's
       // request; each must be updated within the frame, after the panel. `Ui`
@@ -1020,6 +1055,13 @@ impl State {
       }
     });
     let response = response.expect("the closure always runs exactly once");
+
+    // Persist the dismissal once, the frame it happens, so the next launch --
+    // this session's or a later one's -- skips the greeting.
+    if welcome_dismissed {
+      self.show_welcome = false;
+      crate::welcome::mark_seen();
+    }
 
     // A finished file pick, a preset, a mesh-source change and a study switch
     // each replace the field set and the camera's natural orientation

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -1070,6 +1070,15 @@ impl State {
     if response.reset_camera {
       self.camera = default_camera(&self.scene, self.camera.aspect);
     }
+    // A standard view snaps the pose (holding the framing) and commits to
+    // parallel projection, the square-on plan/elevation look the axes single
+    // out. Applied after the orthographic toggle above so the view's own
+    // projection wins the frame they might both touch.
+    if let Some(view) = response.camera_view {
+      let (yaw, pitch) = view.angles();
+      self.camera.snap_to(yaw, pitch);
+      self.camera.orthographic = true;
+    }
 
     // A finished export pick is likewise orthogonal to the shown pair: it reads
     // the current frame and writes it, changing nothing on screen.

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -971,6 +971,9 @@ impl State {
       last_grade: self.gallery.last_grade,
       max_grade: self.gallery.mesh.0.dim(),
       scene_dim: self.scene.topology.dim(),
+      simplex_counts: (0..=self.scene.topology.dim())
+        .map(|k| self.scene.topology.nsimplices(k))
+        .collect(),
       entries,
       mesh_error: self.gallery.error.clone(),
       selection: self.selection,

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -1080,6 +1080,13 @@ impl State {
       }
     }
 
+    // Restart returns the clock to its start and the advected population to its
+    // seeds, exactly as selecting a fresh field does, without leaving the field.
+    if response.restart {
+      self.clock.restart();
+      self.steps_taken = 0;
+    }
+
     // Re-framing the scene reads only its coordinates and the current aspect,
     // touching neither the shown pair nor a buffer, so it applies here with the
     // other orthogonal view changes. It discards a fly-through's pose, which is

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -1063,6 +1063,20 @@ impl State {
     self.post = response.post;
     self.clock.set_playing(response.playing);
 
+    // A trajectory scrub sets the clock so the playhead lands on the requested
+    // solve-time. The clock runs in the playback interval the trajectory maps
+    // onto its own duration, so the target inverts that map: the first loop's
+    // fraction of `TRAJECTORY_LOOP_SECONDS`. Guarded by the field actually
+    // being a trajectory, so a stale request cannot move a static field's clock.
+    if let Some(target) = response.scrub_time {
+      if let Some(duration) = self.scene.field_time(self.selection).duration() {
+        if duration > 0.0 {
+          let clock = (target / duration) * crate::display::TRAJECTORY_LOOP_SECONDS;
+          self.clock.set_time(clock as f32);
+        }
+      }
+    }
+
     // Re-framing the scene reads only its coordinates and the current aspect,
     // touching neither the shown pair nor a buffer, so it applies here with the
     // other orthogonal view changes. It discards a fly-through's pose, which is
@@ -1304,6 +1318,15 @@ impl WaveClock {
   /// current play/pause state.
   fn restart(&mut self) {
     self.base = 0.0;
+    self.anchor = web_time::Instant::now();
+  }
+
+  /// Jumps the clock to `t` animation seconds, keeping the play/pause state: a
+  /// fresh span begins at `t`, so a paused clock holds there and a playing one
+  /// runs on from it. What a transport scrub sets, the playhead the reader
+  /// drags becoming the clock's new base.
+  fn set_time(&mut self, t: f32) {
+    self.base = t.max(0.0);
     self.anchor = web_time::Instant::now();
   }
 }

--- a/crates/studio/src/app.rs
+++ b/crates/studio/src/app.rs
@@ -1063,6 +1063,14 @@ impl State {
     self.post = response.post;
     self.clock.set_playing(response.playing);
 
+    // Re-framing the scene reads only its coordinates and the current aspect,
+    // touching neither the shown pair nor a buffer, so it applies here with the
+    // other orthogonal view changes. It discards a fly-through's pose, which is
+    // the whole point -- the way back when the object has gone off screen.
+    if response.reset_camera {
+      self.camera = default_camera(&self.scene, self.camera.aspect);
+    }
+
     // A finished export pick is likewise orthogonal to the shown pair: it reads
     // the current frame and writes it, changing nothing on screen.
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/studio/src/gallery.rs
+++ b/crates/studio/src/gallery.rs
@@ -57,17 +57,36 @@ pub const REFERENCE_CELL_DIM_MAX: Dim = 3;
 // ($6 + 10 = 16$), so the orbital pyramid the UI lays these out in has no
 // half-built final row.
 pub const DEFAULT_NMODES: usize = 16;
+// The top of the eigenmode-count slider. The per-grade solve is dense
+// ($O(n^3)$) in the shift-invert factorization but the projected subspace is
+// what grows with the mode count, so a cap here keeps the background solve from
+// widening past what stays interactive. Enough to close the sphere's $l = 0..=5$
+// grade-0 pyramid ($sum_(l=0)^5 (2l+1) = 36$) with a full final row.
+pub const EIGENMODES_NMODES_MIN: usize = 1;
+pub const EIGENMODES_NMODES_MAX: usize = 36;
 
 // A time-dependent study samples its solution at this many steps over the
 // solve's final time. Enough that the linear interpolation between frames reads
 // as continuous motion at the trajectory's playback rate.
 pub const DEFAULT_TRAJECTORY_STEPS: usize = 160;
+// The trajectory-sampling slider's range. The lower end still reads as motion
+// under interpolation; the upper end is where the sampled frames stop earning
+// their memory against the linear interpolant between them.
+pub const TRAJECTORY_STEPS_MIN: usize = 10;
+pub const TRAJECTORY_STEPS_MAX: usize = 400;
 // The heat flow's final time: long enough for the initial bump to diffuse and
 // visibly decay on the unit-scale gallery meshes. The wave equation's, in the
 // same units: several periods of the lowest modes, so the fronts propagate and
 // reflect rather than barely stirring.
 pub const HEAT_FINAL_TIME: f64 = 0.5;
 pub const WAVE_FINAL_TIME: f64 = 12.0;
+// The final-time sliders' ranges, one per equation because the two evolve on
+// different scales: the parabolic smoothing settles quickly, the hyperbolic
+// fronts want several periods to propagate and reflect.
+pub const HEAT_FINAL_TIME_MIN: f64 = 0.05;
+pub const HEAT_FINAL_TIME_MAX: f64 = 2.0;
+pub const WAVE_FINAL_TIME_MIN: f64 = 1.0;
+pub const WAVE_FINAL_TIME_MAX: f64 = 30.0;
 
 /// The shared surface mesh a study solves against, built once so every
 /// per-grade eigensolve reuses it rather than remeshing.

--- a/crates/studio/src/gallery.rs
+++ b/crates/studio/src/gallery.rs
@@ -421,6 +421,10 @@ impl CochainSpec {
 /// a preset.
 pub(crate) struct Preset {
   pub(crate) name: &'static str,
+  /// A one-line gloss of what the preset shows, for the browser's hover. It
+  /// names the point in the product in the reader's terms -- the mathematics on
+  /// the mesh -- so the curated set is legible before it is clicked.
+  pub(crate) description: &'static str,
   pub(crate) mesh: MeshSource,
   pub(crate) study: Study,
   /// The field the preset opens on, or `None` to open on the scene's first
@@ -455,6 +459,8 @@ pub(crate) fn start_preset() -> Preset {
 fn curl_on_triforce() -> Preset {
   Preset {
     name: "Constant / curl / div",
+    description:
+      "The three grade-1 cochains on the triforce: a constant field, a pure curl, a pure divergence",
     mesh: MeshSource::Triforce,
     study: Study::Cochains(crate::demos::triforce_examples()),
     // The second of the three (constant, curl, div), all grade 1 and so all
@@ -474,6 +480,7 @@ pub(crate) fn presets() -> Vec<Preset> {
   let mut presets = vec![
     Preset {
       name: "Spherical harmonics",
+      description: "Grade-0 Hodge-Laplace eigenmodes of the sphere: the spherical-harmonic multiplets, laid out as the orbital pyramid",
       mesh: MeshSource::START,
       study: Study::start(),
       selection: None,
@@ -481,6 +488,7 @@ pub(crate) fn presets() -> Vec<Preset> {
     },
     Preset {
       name: "Whitney basis",
+      description: "The local shape functions: the Whitney basis on a single reference cell, one field per DOF simplex",
       mesh: MeshSource::ReferenceCell {
         dim: REFERENCE_CELL_DIM,
       },
@@ -490,6 +498,7 @@ pub(crate) fn presets() -> Vec<Preset> {
     },
     Preset {
       name: "Global shape functions",
+      description: "The Whitney basis on the multi-cell triforce: the global shape functions, whose support spans several cells",
       mesh: MeshSource::Triforce,
       study: Study::WhitneyBasis,
       selection: None,
@@ -498,6 +507,7 @@ pub(crate) fn presets() -> Vec<Preset> {
     curl_on_triforce(),
     Preset {
       name: "Heat equation",
+      description: "Parabolic smoothing of a localized bump on the sphere, sampled as a scrubbable trajectory",
       mesh: MeshSource::START,
       study: Study::Heat {
         nsteps: DEFAULT_TRAJECTORY_STEPS,
@@ -508,6 +518,7 @@ pub(crate) fn presets() -> Vec<Preset> {
     },
     Preset {
       name: "Wave equation",
+      description: "Hyperbolic propagation and reflection of a bump on the sphere, sampled as a scrubbable trajectory",
       mesh: MeshSource::START,
       study: Study::Wave {
         nsteps: DEFAULT_TRAJECTORY_STEPS,
@@ -523,6 +534,7 @@ pub(crate) fn presets() -> Vec<Preset> {
       1,
       Preset {
         name: "Harmonic 1-forms",
+        description: "Grade-1 eigenmodes of a genus-1 surface: the harmonic 1-forms are its zero shell, and they see the hole",
         mesh: MeshSource::Builtin(bob),
         study: Study::Eigenmodes {
           grade: 1,
@@ -538,6 +550,7 @@ pub(crate) fn presets() -> Vec<Preset> {
       // exact + coexact + harmonic, not the contractible Helmholtz special
       // case. Opens on the harmonic shell -- the component that sees the hole.
       name: "Hodge decomposition",
+      description: "A grade-1 field split into exact, coexact and harmonic parts on a genus-1 surface; opens on the harmonic shell",
       mesh: MeshSource::Builtin(bob),
       study: Study::HodgeDecomposition,
       selection: Some(Selection::Line(3)),

--- a/crates/studio/src/lib.rs
+++ b/crates/studio/src/lib.rs
@@ -23,6 +23,7 @@ pub mod render;
 pub mod scene;
 pub(crate) mod solve;
 pub mod ui;
+pub(crate) mod welcome;
 
 /// The web entry point and its platform glue (canvas mount, async device
 /// bootstrap, console logging). Isolated here so nothing web-specific leaks

--- a/crates/studio/src/render/camera.rs
+++ b/crates/studio/src/render/camera.rs
@@ -376,6 +376,19 @@ mod tests {
     }
   }
 
+  /// Snapping to any orientation holds the pivot: the vantage changes while the
+  /// object stays framed, the invariant every canned pose is built on.
+  #[test]
+  fn snap_to_holds_the_pivot() {
+    for (yaw, pitch) in sweep() {
+      let mut c = at(0.4, -0.2);
+      let pivot = c.pivot();
+      c.snap_to(yaw, pitch);
+      assert!((c.forward().norm() - 1.0).abs() < 1e-6);
+      assert!((c.pivot() - pivot).norm() < 1e-4, "yaw={yaw} pitch={pitch}");
+    }
+  }
+
   /// Away from the poles the carried frame reproduces `look_at_rh` exactly:
   /// this camera is its analytic continuation, not a different convention.
   #[test]

--- a/crates/studio/src/render/camera.rs
+++ b/crates/studio/src/render/camera.rs
@@ -189,9 +189,18 @@ impl Camera {
   /// as the anchor, and `yaw` snaps to $pi/2$ so screen-right lands on world
   /// $+x$ ([`Self::right`]) and the plane keeps its own axes.
   pub fn snap_top_down(&mut self) {
+    self.snap_to(FRAC_PI_2, -FRAC_PI_2);
+  }
+
+  /// Snaps the orientation to $(psi, theta)$ while holding the pivot fixed, so
+  /// the object stays framed and only the vantage changes. The one primitive
+  /// behind every canned pose -- [`Self::snap_top_down`] and the axis-aligned
+  /// standard views are each a choice of angles fed through here, the eye
+  /// re-derived from the held pivot exactly as it is on entering the flat view.
+  pub fn snap_to(&mut self, yaw: f32, pitch: f32) {
     let pivot = self.pivot();
-    self.yaw = FRAC_PI_2;
-    self.pitch = -FRAC_PI_2;
+    self.yaw = yaw;
+    self.pitch = pitch;
     self.eye = pivot - self.forward() * self.pivot_distance;
   }
 

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -64,6 +64,59 @@ impl Post {
   pub(crate) const ALL: [Self; 3] = [Self::Clamp, Self::Tonemap, Self::Bloom];
 }
 
+/// A canonical camera vantage: an axis-aligned standard view, each a fixed
+/// $(psi, theta)$ orientation snapped to with the pivot held (`Camera::snap_to`)
+/// and shown in parallel projection, the plan and elevation views of a
+/// draughtsman. The perspective orbit is the free vantage between them; these
+/// are the six the axes single out, offered because reading a mesh's structure
+/// wants a square-on look no free orbit lands on exactly.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum CameraView {
+  Top,
+  Bottom,
+  Front,
+  Back,
+  Right,
+  Left,
+}
+
+impl CameraView {
+  pub(crate) const ALL: [Self; 6] = [
+    Self::Top,
+    Self::Bottom,
+    Self::Front,
+    Self::Back,
+    Self::Right,
+    Self::Left,
+  ];
+
+  pub(crate) fn label(self) -> &'static str {
+    match self {
+      Self::Top => "Top",
+      Self::Bottom => "Bottom",
+      Self::Front => "Front",
+      Self::Back => "Back",
+      Self::Right => "Right",
+      Self::Left => "Left",
+    }
+  }
+
+  /// The $(psi, theta)$ the view snaps to, about [`crate::render::camera::WORLD_UP`]
+  /// ($+z$): the top/bottom look along $mp z$, the four side views along the
+  /// horizontal axes with $+z$ kept screen-up.
+  pub(crate) fn angles(self) -> (f32, f32) {
+    use std::f32::consts::{FRAC_PI_2, PI};
+    match self {
+      Self::Top => (FRAC_PI_2, -FRAC_PI_2),
+      Self::Bottom => (FRAC_PI_2, FRAC_PI_2),
+      Self::Front => (FRAC_PI_2, 0.0),
+      Self::Back => (-FRAC_PI_2, 0.0),
+      Self::Right => (PI, 0.0),
+      Self::Left => (0.0, 0.0),
+    }
+  }
+}
+
 /// How one $k$-skeleton is drawn: whether it appears, and whether it reflects
 /// the field or is the structural geometry ink. The two are independent -- hiding
 /// a skeleton and coloring it are separate choices, and coloring is a no-op while
@@ -703,6 +756,10 @@ pub(crate) struct PanelResponse {
   /// screen. Orthogonal to the shown pair, so the caller applies it
   /// unconditionally like the view toggles.
   pub(crate) reset_camera: bool,
+  /// A standard axis-aligned vantage the reader picked this frame, if any: the
+  /// caller snaps the camera to it (in parallel projection) while holding the
+  /// framing. Orthogonal to the shown pair, like [`Self::reset_camera`].
+  pub(crate) camera_view: Option<CameraView>,
   /// Whether the standing wave should be running after this frame -- the
   /// play/pause toggle. Defaults to the model's own state when the control
   /// wasn't touched, like the other fields.
@@ -765,6 +822,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
   let mut post = model.post;
   let mut orthographic = model.orthographic;
   let mut reset_camera = false;
+  let mut camera_view = None;
   let mut playing = model.playing;
   #[cfg(not(target_arch = "wasm32"))]
   let mut load_obj_clicked = false;
@@ -813,6 +871,14 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
           reset_camera = true;
           ui.close();
         }
+        ui.menu_button("Standard views", |ui| {
+          for view in CameraView::ALL {
+            if ui.button(view.label()).clicked() {
+              camera_view = Some(view);
+              ui.close();
+            }
+          }
+        });
         ui.separator();
         // The display transform, a cumulative ladder rather than a set of
         // independent flags (see `Post`), so a radio and not checkboxes.
@@ -1159,6 +1225,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
     post,
     orthographic,
     reset_camera,
+    camera_view,
     playing,
     #[cfg(not(target_arch = "wasm32"))]
     load_obj_clicked,

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -1436,4 +1436,54 @@ mod tests {
   fn missing_eigenvalue_declines_to_shell() {
     assert!(degeneracy_shells([Some(1.0), None, Some(2.0)]).is_none());
   }
+
+  /// Every standard view looks straight down a coordinate axis: its forward is a
+  /// unit axis vector, one component $plus.minus 1$ and the other two zero. That
+  /// is what makes it the square-on plan/elevation a free orbit never lands on.
+  #[test]
+  fn standard_views_look_down_an_axis() {
+    use crate::render::camera::Camera;
+    for view in CameraView::ALL {
+      let mut camera = Camera::new(1.0);
+      let (yaw, pitch) = view.angles();
+      camera.snap_to(yaw, pitch);
+      let f = camera.forward();
+      let axes = [f.x, f.y, f.z];
+      let ones = axes
+        .iter()
+        .filter(|&&c| (c.abs() - 1.0).abs() < 1e-6)
+        .count();
+      let zeros = axes.iter().filter(|&&c| c.abs() < 1e-6).count();
+      assert_eq!(ones, 1, "{}: forward {f:?} is not an axis", view.label());
+      assert_eq!(zeros, 2, "{}: forward {f:?} is not an axis", view.label());
+    }
+    // And the six are distinct vantages, not a shorter list with repeats.
+    let dirs: std::collections::HashSet<[i32; 3]> = CameraView::ALL
+      .iter()
+      .map(|v| {
+        let mut c = Camera::new(1.0);
+        let (yaw, pitch) = v.angles();
+        c.snap_to(yaw, pitch);
+        let f = c.forward();
+        [f.x.round() as i32, f.y.round() as i32, f.z.round() as i32]
+      })
+      .collect();
+    assert_eq!(dirs.len(), 6, "the six standard views must be distinct");
+  }
+
+  /// The size caption names every dimension present and totals over the whole
+  /// range, so it reads right in any dimension rather than for a fixed few
+  /// skeletons -- the low dimensions by their classical names, higher ones by
+  /// the general "$k$-simplices".
+  #[test]
+  fn mesh_stats_line_names_each_dimension() {
+    assert_eq!(
+      mesh_stats_line(&[12, 30, 20]),
+      "12 vertices · 30 edges · 20 faces"
+    );
+    assert_eq!(
+      mesh_stats_line(&[5, 10, 10, 5, 1]),
+      "5 vertices · 10 edges · 10 faces · 5 cells · 1 4-simplices"
+    );
+  }
 }

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -698,6 +698,11 @@ pub(crate) struct PanelResponse {
   pub(crate) field_view: FieldView,
   pub(crate) post: Post,
   pub(crate) orthographic: bool,
+  /// Whether "Reset camera" was clicked: re-frame the scene from its own
+  /// coordinates, the one way back once a fly-through has left the object off
+  /// screen. Orthogonal to the shown pair, so the caller applies it
+  /// unconditionally like the view toggles.
+  pub(crate) reset_camera: bool,
   /// Whether the standing wave should be running after this frame -- the
   /// play/pause toggle. Defaults to the model's own state when the control
   /// wasn't touched, like the other fields.
@@ -759,6 +764,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
   let mut field_view = model.field_view;
   let mut post = model.post;
   let mut orthographic = model.orthographic;
+  let mut reset_camera = false;
   let mut playing = model.playing;
   #[cfg(not(target_arch = "wasm32"))]
   let mut load_obj_clicked = false;
@@ -799,6 +805,14 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
         ui.separator();
         ui.checkbox(&mut orthographic, "Orthographic")
           .on_hover_text("Parallel projection: no vanishing point, so a flat mesh keeps its scale");
+        if ui
+          .button("Reset camera")
+          .on_hover_text("Re-frame the scene from its own extent")
+          .clicked()
+        {
+          reset_camera = true;
+          ui.close();
+        }
         ui.separator();
         // The display transform, a cumulative ladder rather than a set of
         // independent flags (see `Post`), so a radio and not checkboxes.
@@ -828,7 +842,11 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
 
         section(ui, "Presets", |ui| {
           for (i, preset) in model.presets.iter().enumerate() {
-            if ui.selectable_label(false, preset.name).clicked() {
+            if ui
+              .selectable_label(false, preset.name)
+              .on_hover_text(preset.description)
+              .clicked()
+            {
               requested_preset = Some(i);
             }
           }
@@ -1140,6 +1158,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
     field_view,
     post,
     orthographic,
+    reset_camera,
     playing,
     #[cfg(not(target_arch = "wasm32"))]
     load_obj_clicked,

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -9,9 +9,11 @@ use simplicial::{topology::simplex::Simplex, Dim};
 
 use crate::gallery::{
   BuiltinMesh, MeshSource, Preset, Study, DEFAULT_NMODES, DEFAULT_TRAJECTORY_STEPS,
-  GRID_CELLS_DEFAULT, GRID_CELLS_MAX, GRID_DIM_DEFAULT, GRID_DIM_MAX, HEAT_FINAL_TIME,
+  EIGENMODES_NMODES_MAX, EIGENMODES_NMODES_MIN, GRID_CELLS_DEFAULT, GRID_CELLS_MAX,
+  GRID_DIM_DEFAULT, GRID_DIM_MAX, HEAT_FINAL_TIME, HEAT_FINAL_TIME_MAX, HEAT_FINAL_TIME_MIN,
   REFERENCE_CELL_DIM, REFERENCE_CELL_DIM_MAX, SPHERE_SUBDIVISIONS, SPHERE_SUBDIVISIONS_MAX,
-  WAVE_FINAL_TIME,
+  TRAJECTORY_STEPS_MAX, TRAJECTORY_STEPS_MIN, WAVE_FINAL_TIME, WAVE_FINAL_TIME_MAX,
+  WAVE_FINAL_TIME_MIN,
 };
 use crate::scene::{dof_label, FieldOffers};
 
@@ -534,6 +536,109 @@ pub(crate) fn grade_mark_label(grade: ExteriorGrade, n: Dim) -> String {
   }
 }
 
+/// A slider whose edit is *committed* only when the handle is released (or the
+/// value is typed and confirmed), never mid-drag. It edits `value` live so the
+/// readout tracks the pointer, but returns `true` only on the frame the gesture
+/// ends -- so a parameter that drives an expensive rebuild (an eigensolve, a
+/// trajectory) re-solves once on release rather than on every frame the handle
+/// sweeps through. `changed() && !dragged()` catches the keyboard/step edits a
+/// drag never emits.
+fn commit_slider<Num: egui::emath::Numeric>(
+  ui: &mut egui::Ui,
+  value: &mut Num,
+  range: std::ops::RangeInclusive<Num>,
+  text: &str,
+) -> bool {
+  let response = ui.add(egui::Slider::new(value, range).text(text));
+  response.drag_stopped() || (response.changed() && !response.dragged())
+}
+
+/// The selected study's own parameters, edited in place against `study`.
+/// Returns whether the edit should be applied this frame: a discrete change (a
+/// grade tab) commits at once, a slider only when its drag ends (see
+/// [`commit_slider`]), so the re-solve the change triggers fires once. A study
+/// with no free parameters (the Whitney basis, the Hodge decomposition, an
+/// explicit cochain list) draws nothing and commits nothing.
+///
+/// This is where [`Study`]'s variant parameters become editable -- the browser
+/// picks *which* study, and this edits the one picked, the split the crate's
+/// `CLAUDE.md` draws between the two panels.
+fn study_params(ui: &mut egui::Ui, study: &mut Study, max_grade: Dim) -> bool {
+  match study {
+    Study::Eigenmodes { grade, nmodes } => {
+      // One tab per grade of the de Rham complex; every grade is solved and
+      // shown, the top grade through its Hodge star just like grade 0. A grade
+      // change commits at once -- it is a different eigenproblem, not a knob on
+      // the current one.
+      let mut commit = false;
+      ui.horizontal_wrapped(|ui| {
+        for g in 0..=max_grade {
+          if ui
+            .selectable_label(*grade == g, grade_mark_label(g, max_grade))
+            .clicked()
+            && *grade != g
+          {
+            *grade = g;
+            commit = true;
+          }
+        }
+      });
+      commit
+        | commit_slider(
+          ui,
+          nmodes,
+          EIGENMODES_NMODES_MIN..=EIGENMODES_NMODES_MAX,
+          "modes",
+        )
+    }
+    Study::Heat { nsteps, final_time } => {
+      let steps = commit_slider(
+        ui,
+        nsteps,
+        TRAJECTORY_STEPS_MIN..=TRAJECTORY_STEPS_MAX,
+        "steps",
+      );
+      let time = commit_slider(
+        ui,
+        final_time,
+        HEAT_FINAL_TIME_MIN..=HEAT_FINAL_TIME_MAX,
+        "final t",
+      );
+      steps | time
+    }
+    Study::Wave { nsteps, final_time } => {
+      let steps = commit_slider(
+        ui,
+        nsteps,
+        TRAJECTORY_STEPS_MIN..=TRAJECTORY_STEPS_MAX,
+        "steps",
+      );
+      let time = commit_slider(
+        ui,
+        final_time,
+        WAVE_FINAL_TIME_MIN..=WAVE_FINAL_TIME_MAX,
+        "final t",
+      );
+      steps | time
+    }
+    Study::WhitneyBasis | Study::HodgeDecomposition | Study::Cochains(_) => false,
+  }
+}
+
+/// The one-line equation each study is solving, for the inspector's caption. A
+/// reader who knows the mathematics recognizes the study from its equation;
+/// one who does not has the name above it.
+fn study_equation(study: &Study) -> &'static str {
+  match study {
+    Study::Eigenmodes { .. } => "Δu = λu · standing modes",
+    Study::WhitneyBasis => "grade × DOF · the Whitney basis",
+    Study::HodgeDecomposition => "ω = dα + δβ + h",
+    Study::Heat { .. } => "∂ₜu = −Δu · parabolic",
+    Study::Wave { .. } => "∂ₜₜu = −Δu · hyperbolic",
+    Study::Cochains(_) => "explicit cochains",
+  }
+}
+
 /// Everything the panel reads to draw one frame -- a snapshot, not a live
 /// borrow, so building it and rendering the panel cannot conflict with the
 /// `&mut self` calls the caller makes to apply the response afterward.
@@ -611,13 +716,13 @@ pub(crate) struct PanelResponse {
   pub(crate) export_png_clicked: bool,
 }
 
-/// Builds and tessellates the docked shell: a left sidebar (the preset browser
-/// and the two raw axes, mesh and study, for free composition), a right
-/// inspector (the study's own knobs -- eigenmode grade tabs, the mode picker or
-/// basis grid, or a spinner while it solves -- and the camera-mode toggle), a
-/// bottom transport bar (play/pause and the standing wave's readouts), and the
-/// field-name viewport overlay. No central panel is drawn, so the wgpu scene
-/// shows through the middle.
+/// Builds and tessellates the control shell: a top menu bar (file and view
+/// commands), a left sidebar (the preset browser and the two platform axes,
+/// mesh and study, for free composition), a right inspector (the study's own
+/// parameters, its mode picker or basis grid or a spinner while it solves, and
+/// the display settings for the two objects on screen), and a bottom transport
+/// bar (the sidebar toggles, play/pause and the standing wave's readouts). No
+/// central panel is drawn, so the wgpu scene shows through the middle.
 ///
 /// A pure function of `model`: it reads no other state and its only side effect
 /// is on `ctx`'s own egui pass, so the caller is free to apply the returned
@@ -660,28 +765,158 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
   #[cfg(not(target_arch = "wasm32"))]
   let mut export_png_clicked = false;
 
-  // Left sidebar: the browser. The curated presets on top -- each a point in
-  // the mesh × study product, chosen as a whole -- then the raw two axes below.
-  egui::Panel::left("browser")
-    .default_size(side_width)
-    .show_collapsible(ui, &mut browser_open, |ui| {
-      ui.add_space(4.0);
-      ui.heading("Browser");
-      ui.separator();
-
-      section(ui, "Presets", |ui| {
-        for (i, preset) in model.presets.iter().enumerate() {
-          if ui.selectable_label(false, preset.name).clicked() {
-            requested_preset = Some(i);
-          }
+  // Top menu bar: the commands that are not a property of either object on
+  // screen -- reading and writing files, and how the shell itself is laid out
+  // and lit. Drawn first so it spans the full width above the sidebars, the
+  // conventional home a reader reaches for these by reflex.
+  egui::Panel::top("menubar").show(ui, |ui| {
+    egui::MenuBar::new().ui(ui, |ui| {
+      // File is native only: the web build has no local filesystem to read a
+      // mesh from or write a still to, so the whole menu is absent there rather
+      // than shown with dead entries.
+      #[cfg(not(target_arch = "wasm32"))]
+      ui.menu_button("File", |ui| {
+        if ui.button("Load OBJ…").clicked() {
+          load_obj_clicked = true;
+          ui.close();
+        }
+        if ui
+          .button("Export PNG…")
+          .on_hover_text("Save the current view as a still")
+          .clicked()
+        {
+          export_png_clicked = true;
+          ui.close();
         }
       });
 
-      // The study axis. Eigenmodes and the Whitney basis are the two generic
-      // studies; an explicit cochain list has no generic form to pick, so it
-      // shows as the selected study only when a preset installed it.
-      section(ui, "Study", |ui| {
-        ui.horizontal_wrapped(|ui| {
+      ui.menu_button("View", |ui| {
+        // The sidebar toggles, mirrored from the transport bar: a reader who
+        // thinks of "show the panels" as a view command finds it here, and one
+        // who reaches for the bottom-bar icons finds it there.
+        ui.checkbox(&mut browser_open, "Browser");
+        ui.checkbox(&mut inspector_open, "Inspector");
+        ui.separator();
+        ui.checkbox(&mut orthographic, "Orthographic")
+          .on_hover_text("Parallel projection: no vanishing point, so a flat mesh keeps its scale");
+        ui.separator();
+        // The display transform, a cumulative ladder rather than a set of
+        // independent flags (see `Post`), so a radio and not checkboxes.
+        ui.label("Light");
+        for rung in Post::ALL {
+          ui.radio_value(&mut post, rung, rung.label());
+        }
+      });
+
+      ui.menu_button("Help", |ui| {
+        ui.label(concat!("formoniq-studio ", env!("CARGO_PKG_VERSION")));
+        ui.label("A viewer for FEEC meshes, cochains and PDE solutions.");
+      });
+    });
+  });
+
+  // Left sidebar: the browser -- what object to build. The curated presets on
+  // top, each a whole point in the mesh × study product, then the two axes
+  // below for free composition.
+  egui::Panel::left("browser")
+    .default_size(side_width)
+    .show_collapsible(ui, &mut browser_open, |ui| {
+      egui::ScrollArea::vertical().show(ui, |ui| {
+        ui.add_space(4.0);
+        ui.heading("Browser");
+        ui.separator();
+
+        section(ui, "Presets", |ui| {
+          for (i, preset) in model.presets.iter().enumerate() {
+            if ui.selectable_label(false, preset.name).clicked() {
+              requested_preset = Some(i);
+            }
+          }
+        });
+
+        // The mesh axis: every study runs on every mesh, so the picker is
+        // always shown. A generated family resets to its default refinement
+        // when first chosen; its refinement sliders commit on release so a
+        // drag re-solves once, not every frame it sweeps.
+        //
+        // "Mesh source", not "Mesh": this is which object to build, while the
+        // inspector's "Mesh" is what of it to draw. Two questions, and the
+        // longer name is the one that says which this is.
+        section(ui, "Mesh source", |ui| {
+          egui::ComboBox::from_id_salt("mesh-source")
+            .selected_text(requested_mesh.label())
+            .show_ui(ui, |ui| {
+              let is_sphere = matches!(requested_mesh, MeshSource::Sphere { .. });
+              if ui.selectable_label(is_sphere, "Sphere").clicked() && !is_sphere {
+                requested_mesh = MeshSource::Sphere {
+                  subdivisions: SPHERE_SUBDIVISIONS,
+                };
+              }
+              let is_grid = matches!(requested_mesh, MeshSource::Grid { .. });
+              if ui.selectable_label(is_grid, "Grid").clicked() && !is_grid {
+                requested_mesh = MeshSource::Grid {
+                  dim: GRID_DIM_DEFAULT,
+                  cells_axis: GRID_CELLS_DEFAULT,
+                };
+              }
+              let is_ref = matches!(requested_mesh, MeshSource::ReferenceCell { .. });
+              if ui.selectable_label(is_ref, "Reference cell").clicked() && !is_ref {
+                requested_mesh = MeshSource::ReferenceCell {
+                  dim: REFERENCE_CELL_DIM,
+                };
+              }
+              let is_triforce = matches!(requested_mesh, MeshSource::Triforce);
+              if ui.selectable_label(is_triforce, "Triforce").clicked() {
+                requested_mesh = MeshSource::Triforce;
+              }
+              for builtin in BuiltinMesh::all() {
+                let selected = requested_mesh == MeshSource::Builtin(builtin);
+                if ui.selectable_label(selected, builtin.label()).clicked() {
+                  requested_mesh = MeshSource::Builtin(builtin);
+                }
+              }
+            });
+
+          // The refinement sliders of a generated family, edited against a
+          // draft and committed only on release: switching family (the combo
+          // above) applies at once, but sweeping a slider must not respawn the
+          // background solve on every frame of the drag.
+          let mut draft = requested_mesh.clone();
+          let committed = match &mut draft {
+            MeshSource::Sphere { subdivisions } => commit_slider(
+              ui,
+              subdivisions,
+              0..=SPHERE_SUBDIVISIONS_MAX,
+              "subdivisions",
+            ),
+            MeshSource::Grid { dim, cells_axis } => {
+              let d = commit_slider(ui, dim, 1..=GRID_DIM_MAX, "dimension");
+              let c = commit_slider(ui, cells_axis, 1..=GRID_CELLS_MAX, "cells/axis");
+              d | c
+            }
+            MeshSource::ReferenceCell { dim } => {
+              commit_slider(ui, dim, 1..=REFERENCE_CELL_DIM_MAX, "dimension")
+            }
+            MeshSource::Triforce
+            | MeshSource::Builtin(_)
+            | MeshSource::Custom { .. }
+            | MeshSource::File(_) => false,
+          };
+          if committed {
+            requested_mesh = draft;
+          }
+          if let Some(error) = &model.mesh_error {
+            ui.colored_label(egui::Color32::LIGHT_RED, format!("⚠ {error}"));
+          }
+        });
+
+        // The study axis: which computation to run on the mesh. Eigenmodes, the
+        // Whitney basis, the Hodge decomposition and the two time-dependent
+        // solves are the generic studies picked here; an explicit cochain list
+        // has no generic form to pick, so it shows as the selected study only
+        // when a preset installed it. The parameters of the picked study are the
+        // inspector's, not this list's.
+        section(ui, "Study", |ui| {
           let on_eigenmodes = matches!(model.study, Study::Eigenmodes { .. });
           if ui.selectable_label(on_eigenmodes, "Eigenmodes").clicked() && !on_eigenmodes {
             requested_study = Study::Eigenmodes {
@@ -719,210 +954,96 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
           }
         });
       });
-
-      // The mesh axis: every study runs on every mesh, so the picker is always
-      // shown. A generated family resets to its default refinement when first
-      // chosen; re-picking the current family keeps the slider's value.
-      //
-      // "Mesh source", not "Mesh": this is which object to build, while the
-      // inspector's "Mesh" is what of it to draw. Two questions, and the longer
-      // name is the one that says which this is.
-      section(ui, "Mesh source", |ui| {
-        egui::ComboBox::from_id_salt("mesh-source")
-          .selected_text(requested_mesh.label())
-          .show_ui(ui, |ui| {
-            let is_sphere = matches!(requested_mesh, MeshSource::Sphere { .. });
-            if ui.selectable_label(is_sphere, "Sphere").clicked() && !is_sphere {
-              requested_mesh = MeshSource::Sphere {
-                subdivisions: SPHERE_SUBDIVISIONS,
-              };
-            }
-            let is_grid = matches!(requested_mesh, MeshSource::Grid { .. });
-            if ui.selectable_label(is_grid, "Grid").clicked() && !is_grid {
-              requested_mesh = MeshSource::Grid {
-                dim: GRID_DIM_DEFAULT,
-                cells_axis: GRID_CELLS_DEFAULT,
-              };
-            }
-            let is_ref = matches!(requested_mesh, MeshSource::ReferenceCell { .. });
-            if ui.selectable_label(is_ref, "Reference cell").clicked() && !is_ref {
-              requested_mesh = MeshSource::ReferenceCell {
-                dim: REFERENCE_CELL_DIM,
-              };
-            }
-            let is_triforce = matches!(requested_mesh, MeshSource::Triforce);
-            if ui.selectable_label(is_triforce, "Triforce").clicked() {
-              requested_mesh = MeshSource::Triforce;
-            }
-            for builtin in BuiltinMesh::all() {
-              let selected = requested_mesh == MeshSource::Builtin(builtin);
-              if ui.selectable_label(selected, builtin.label()).clicked() {
-                requested_mesh = MeshSource::Builtin(builtin);
-              }
-            }
-          });
-        // A generated family or the reference cell carries a slider; a built-in,
-        // the triforce or a loaded mesh has none.
-        match &mut requested_mesh {
-          MeshSource::Sphere { subdivisions } => {
-            ui.add(
-              egui::Slider::new(subdivisions, 0..=SPHERE_SUBDIVISIONS_MAX).text("subdivisions"),
-            );
-          }
-          MeshSource::Grid { dim, cells_axis } => {
-            ui.add(egui::Slider::new(dim, 1..=GRID_DIM_MAX).text("dimension"));
-            ui.add(egui::Slider::new(cells_axis, 1..=GRID_CELLS_MAX).text("cells/axis"));
-          }
-          MeshSource::ReferenceCell { dim } => {
-            ui.add(egui::Slider::new(dim, 1..=REFERENCE_CELL_DIM_MAX).text("dimension"));
-          }
-          MeshSource::Triforce
-          | MeshSource::Builtin(_)
-          | MeshSource::Custom { .. }
-          | MeshSource::File(_) => {}
-        }
-        // Opens the in-egui file browser; the pick itself is retrieved by the
-        // caller, which owns the (native-only) `egui_file_dialog` state. Absent on
-        // the web, which has no local filesystem to browse.
-        #[cfg(not(target_arch = "wasm32"))]
-        if ui.button("Load OBJ…").clicked() {
-          load_obj_clicked = true;
-        }
-        if let Some(error) = &model.mesh_error {
-          ui.colored_label(egui::Color32::LIGHT_RED, format!("⚠ {error}"));
-        }
-      });
     });
 
-  // Right inspector: the knobs of what is shown -- the study's own parameters
-  // and the camera mode.
+  // Right inspector: what is shown of the object the browser built. The study's
+  // own parameters and its mode picker, then the display settings for the two
+  // objects on screen -- the mesh, and the field read on it.
   egui::Panel::right("inspector")
     .default_size(if compact { side_width } else { 250.0 })
     .show_collapsible(ui, &mut inspector_open, |ui| {
-      ui.add_space(4.0);
-      ui.heading("Inspector");
-      ui.separator();
-
-      // One tab per grade of the de Rham complex; every grade is solved and
-      // shown, the top grade through its Hodge star just like grade 0.
-      if let Study::Eigenmodes { grade, .. } = &model.study {
-        let grade = *grade;
-        ui.horizontal_wrapped(|ui| {
-          for g in 0..=model.max_grade {
-            if ui
-              .selectable_label(g == grade, grade_mark_label(g, model.max_grade))
-              .clicked()
-            {
-              requested_study = Study::Eigenmodes {
-                grade: g,
-                nmodes: DEFAULT_NMODES,
-              };
-            }
-          }
-        });
+      egui::ScrollArea::vertical().show(ui, |ui| {
+        ui.add_space(4.0);
+        ui.heading("Inspector");
         ui.separator();
-      }
 
-      if model.is_loading {
-        ui.horizontal(|ui| {
-          ui.add(egui::Spinner::new().size(20.0));
-          if let Some(label) = &model.loading_label {
-            ui.label(format!("Solving {label}…"));
+        // The study section: the equation it solves, then its own editable
+        // parameters. The grade tabs, the mode count, the sampling steps -- the
+        // knobs of `Study`'s variant, edited here where the crate's CLAUDE.md
+        // says they live. A committed edit re-requests the study, which
+        // re-solves it; while it does, the spinner below replaces the picker.
+        section(ui, "Study", |ui| {
+          ui.weak(study_equation(&model.study));
+          // Edit a draft of the *live* study, not the value the browser may
+          // have just replaced this frame: a type switch above and a parameter
+          // edit here never both fire, and basing the draft on the live study
+          // keeps the two from racing.
+          let mut study_draft = model.study.clone();
+          if study_params(ui, &mut study_draft, model.max_grade) && requested_study == model.study {
+            requested_study = study_draft;
           }
         });
-      } else {
-        match &model.study {
-          Study::Eigenmodes { .. } => {
-            ui.label("λ shell × order");
-          }
-          Study::WhitneyBasis => {
-            ui.label("grade × DOF");
-          }
-          Study::HodgeDecomposition => {
-            ui.label("ω = dα + δβ + h");
-          }
-          Study::Heat { .. } => {
-            ui.label("∂ₜu = −Δu");
-          }
-          Study::Wave { .. } => {
-            ui.label("∂ₜₜu = −Δu");
-          }
-          Study::Cochains(_) => {}
-        };
-        render_modes(ui, &model.entries, &mut selection, model.scene_dim);
-      }
 
-      // What is drawn, in two sections by which object the setting reads: the
-      // mesh, and the field read on it. That is `display.rs`'s own seam between
-      // `MeshDisplay` and `FieldDisplay`, so these mirror a distinction the code
-      // already makes rather than laying a second taxonomy over it.
-      // The skeletons, as peers: one row per k-skeleton the mesh has
-      // (k <= min(n, 2)), faces at the top, each with the same two questions --
-      // drawn, and colored by the field or left as structural geometry.
-      section(ui, "Skeletons", |ui| {
-      for k in (0..=model.scene_dim.min(2)).rev() {
-        let sk = &mut mesh_view.skeletons[k];
-        ui.horizontal(|ui| {
-          ui.checkbox(&mut sk.visible, skeleton_label(k))
-            .on_hover_text(skeleton_hover(k));
-          ui.add_enabled(sk.visible, egui::Checkbox::new(&mut sk.colored, "color"))
-            .on_hover_text("Reflect the selected field on this skeleton as a heatmap, instead of the structural geometry ink");
+        section(ui, "Modes", |ui| {
+          if model.is_loading {
+            ui.horizontal(|ui| {
+              ui.add(egui::Spinner::new().size(20.0));
+              if let Some(label) = &model.loading_label {
+                ui.label(format!("Solving {label}…"));
+              }
+            });
+          } else {
+            render_modes(ui, &model.entries, &mut selection, model.scene_dim);
+          }
         });
-      }
-      });
 
-      // The field side is the only one gated, and it asks rather than
-      // dispatches: which settings a field offers is its reduced grade's answer
-      // (`Scene::offers`). A knob with nothing to toggle is a knob whose only
-      // use is to be wrong -- and a section with no knobs is one too, so a
-      // density that is no eigenmode shows no section at all.
-      if model.offers.any() {
-        section(ui, "Field", |ui| {
-        if model.offers.displacement {
-          ui.checkbox(&mut field_view.displacement, "Displacement")
-            .on_hover_text("The standing wave, along the surface's normal: the mode's own geometry");
+        // What is drawn, in two sections by which object the setting reads: the
+        // mesh, and the field read on it. That is `display.rs`'s own seam
+        // between `MeshDisplay` and `FieldDisplay`, so these mirror a
+        // distinction the code already makes rather than laying a second
+        // taxonomy over it.
+        //
+        // The skeletons, as peers: one row per k-skeleton the mesh has
+        // (k <= min(n, 2)), faces at the top, each with the same two questions
+        // -- drawn, and colored by the field or left as structural geometry.
+        section(ui, "Mesh", |ui| {
+          for k in (0..=model.scene_dim.min(2)).rev() {
+            let sk = &mut mesh_view.skeletons[k];
+            ui.horizontal(|ui| {
+              ui.checkbox(&mut sk.visible, skeleton_label(k))
+                .on_hover_text(skeleton_hover(k));
+              ui.add_enabled(sk.visible, egui::Checkbox::new(&mut sk.colored, "color"))
+                .on_hover_text("Reflect the selected field on this skeleton as a heatmap, instead of the structural geometry ink");
+            });
+          }
+        });
+
+        // The field side is the only one gated, and it asks rather than
+        // dispatches: which settings a field offers is its reduced grade's
+        // answer (`Scene::offers`). A knob with nothing to toggle is a knob
+        // whose only use is to be wrong -- and a section with no knobs is one
+        // too, so a density that is no eigenmode shows no section at all.
+        if model.offers.any() {
+          section(ui, "Field", |ui| {
+            if model.offers.displacement {
+              ui.checkbox(&mut field_view.displacement, "Displacement")
+                .on_hover_text("The standing wave, along the surface's normal: the mode's own geometry");
+            }
+            if model.offers.marks {
+              ui.checkbox(&mut field_view.marks.glyphs, "Glyphs")
+                .on_hover_text("Arrows on each cell's barycentric lattice: the field at a point");
+              ui.checkbox(&mut field_view.marks.particles, "Particles")
+                .on_hover_text("Advected points: the field's dynamics, legible in motion");
+            }
+          });
         }
-        if model.offers.marks {
-          ui.checkbox(&mut field_view.marks.glyphs, "Glyphs")
-            .on_hover_text("Arrows on each cell's barycentric lattice: the field at a point");
-          ui.checkbox(&mut field_view.marks.particles, "Particles")
-            .on_hover_text("Advected points: the field's dynamics, legible in motion");
-        }
-        });
-      }
-
-      // Radio, not two checkboxes: the rungs are cumulative, so the states are
-      // three and not four.
-      section(ui, "Light", |ui| {
-        ui.horizontal_wrapped(|ui| {
-          for rung in Post::ALL {
-            ui.radio_value(&mut post, rung, rung.label());
-          }
-        });
       });
-
-      ui.separator();
-      ui.checkbox(&mut orthographic, "Orthographic")
-        .on_hover_text("Parallel projection: no vanishing point, so a flat mesh keeps its scale");
-
-      // Writes exactly what is on screen -- the current field, camera and wave
-      // phase -- as a PNG still, at the window's own resolution and the export
-      // supersampling. The clip export the transport bar would host is a
-      // separate, later concern; this is the plain screenshot. Native only:
-      // there is no local filesystem to save to on the web.
-      #[cfg(not(target_arch = "wasm32"))]
-      if ui
-        .button("Export PNG…")
-        .on_hover_text("Save the current view as a still")
-        .clicked()
-      {
-        export_png_clicked = true;
-      }
     });
 
-  // Bottom transport bar: play/pause and the standing wave's readouts. Only an
-  // oscillating mode ($omega > 0$) has a wave to run, so the toggle is disabled
-  // for a static or harmonic field, where it would control nothing.
+  // Bottom transport bar: the sidebar toggles, play/pause and the standing
+  // wave's readouts. Only an oscillating mode ($omega > 0$) or a sampled
+  // trajectory has a clock to run, so the toggle is disabled for a static or
+  // harmonic field, where it would control nothing.
   egui::Panel::bottom("transport").show(ui, |ui| {
     ui.add_space(2.0);
     ui.horizontal(|ui| {

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -558,6 +558,31 @@ fn section(ui: &mut egui::Ui, title: &str, body: impl FnOnce(&mut egui::Ui)) {
 /// A $k$-skeleton's label, with the render primitive it draws to: the reader
 /// sees both the intrinsic object and its picture. Faces, edges, points are the
 /// $k <= 2$ the ambient reaches.
+/// The noun for a $k$-simplex, so a count reads in the reader's terms: the low
+/// dimensions have their classical names, and anything higher is the general
+/// "$k$-simplices" rather than a name that would only exist for one dimension.
+fn simplex_noun(k: usize) -> String {
+  match k {
+    0 => "vertices".to_string(),
+    1 => "edges".to_string(),
+    2 => "faces".to_string(),
+    3 => "cells".to_string(),
+    _ => format!("{k}-simplices"),
+  }
+}
+
+/// A one-line size caption from the per-dimension simplex counts: "12 vertices ·
+/// 30 edges · 20 faces". Total over the range, so it stays right in any
+/// dimension rather than naming a fixed few skeletons.
+fn mesh_stats_line(counts: &[usize]) -> String {
+  counts
+    .iter()
+    .enumerate()
+    .map(|(k, n)| format!("{n} {}", simplex_noun(k)))
+    .collect::<Vec<_>>()
+    .join(" · ")
+}
+
 pub(crate) fn skeleton_label(k: usize) -> String {
   let primitive = match k {
     0 => "points",
@@ -705,6 +730,10 @@ pub(crate) struct PanelModel<'a> {
   pub(crate) last_grade: ExteriorGrade,
   pub(crate) max_grade: Dim,
   pub(crate) scene_dim: Dim,
+  /// The mesh's simplex count per dimension, indexed by $k in 0..="scene_dim"$:
+  /// the vertices, edges, faces and up. A caption of the object's size, read
+  /// straight off the topology so it needs no embedding.
+  pub(crate) simplex_counts: Vec<usize>,
   pub(crate) entries: Vec<Entry<'a>>,
   pub(crate) mesh_error: Option<String>,
   pub(crate) selection: Selection,
@@ -897,6 +926,20 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
       ui.menu_button("Help", |ui| {
         ui.label(concat!("formoniq-studio ", env!("CARGO_PKG_VERSION")));
         ui.label("A viewer for FEEC meshes, cochains and PDE solutions.");
+        ui.separator();
+        ui.menu_button("Navigation", |ui| {
+          // The controls the viewport reads, which no widget announces on its
+          // own -- so a reader who never guesses the drags never finds them.
+          // Phrased by projection, mirroring the input split in `app.rs`.
+          ui.label(egui::RichText::new("Perspective (curved mesh)").strong());
+          ui.label("Left-drag: orbit · Right-drag: look · Middle-drag: pan");
+          ui.label("Scroll: zoom to cursor · WASD: fly · Space/Shift: up/down · Ctrl: sprint");
+          ui.separator();
+          ui.label(egui::RichText::new("Orthographic (flat mesh)").strong());
+          ui.label("Drag: pan · Scroll: zoom · WASD: pan · Space/Shift: zoom out/in");
+          ui.separator();
+          ui.label("Touch: one finger looks/pans · two pinch to zoom and drag to pan");
+        });
       });
     });
   });
@@ -1097,6 +1140,8 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
         // (k <= min(n, 2)), faces at the top, each with the same two questions
         // -- drawn, and colored by the field or left as structural geometry.
         section(ui, "Mesh", |ui| {
+          ui.weak(mesh_stats_line(&model.simplex_counts))
+            .on_hover_text("Simplex count per skeleton dimension, read off the topology");
           for k in (0..=model.scene_dim.min(2)).rev() {
             let sk = &mut mesh_view.skeletons[k];
             ui.horizontal(|ui| {

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -794,6 +794,10 @@ pub(crate) struct PanelResponse {
   /// the trajectory slider moved -- a static field and an eigenmode have no
   /// timeline to scrub.
   pub(crate) scrub_time: Option<f64>,
+  /// Whether "Restart" was clicked: the caller returns the clock to its start
+  /// -- a trajectory's first frame, a standing wave's crest -- keeping the
+  /// play/pause state.
+  pub(crate) restart: bool,
   /// Whether the standing wave should be running after this frame -- the
   /// play/pause toggle. Defaults to the model's own state when the control
   /// wasn't touched, like the other fields.
@@ -858,6 +862,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
   let mut reset_camera = false;
   let mut camera_view = None;
   let mut scrub_time = None;
+  let mut restart = false;
   let mut playing = model.playing;
   #[cfg(not(target_arch = "wasm32"))]
   let mut load_obj_clicked = false;
@@ -1217,6 +1222,16 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
       // A field runs a clock when it oscillates (an eigenmode) or when it is a
       // sampled trajectory; only a static or harmonic field has nothing to play.
       let has_clock = omega.is_some_and(|w| w > 1e-9) || model.trajectory.is_some();
+      // Back to the start: a trajectory's first frame, a standing wave's crest.
+      // Disabled with the play control, since a field with no clock has no start
+      // to return to.
+      if ui
+        .add_enabled(has_clock, egui::Button::new("⏮"))
+        .on_hover_text("Restart")
+        .clicked()
+      {
+        restart = true;
+      }
       let label = if playing { "⏸" } else { "▶" };
       if ui
         .add_enabled(has_clock, egui::Button::new(label))
@@ -1296,6 +1311,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
     reset_camera,
     camera_view,
     scrub_time,
+    restart,
     playing,
     #[cfg(not(target_arch = "wasm32"))]
     load_obj_clicked,

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -760,6 +760,11 @@ pub(crate) struct PanelResponse {
   /// caller snaps the camera to it (in parallel projection) while holding the
   /// framing. Orthogonal to the shown pair, like [`Self::reset_camera`].
   pub(crate) camera_view: Option<CameraView>,
+  /// A solve-time the reader scrubbed the trajectory timeline to this frame, if
+  /// any: the caller jumps its clock so the playhead lands there. `None` unless
+  /// the trajectory slider moved -- a static field and an eigenmode have no
+  /// timeline to scrub.
+  pub(crate) scrub_time: Option<f64>,
   /// Whether the standing wave should be running after this frame -- the
   /// play/pause toggle. Defaults to the model's own state when the control
   /// wasn't touched, like the other fields.
@@ -823,6 +828,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
   let mut orthographic = model.orthographic;
   let mut reset_camera = false;
   let mut camera_view = None;
+  let mut scrub_time = None;
   let mut playing = model.playing;
   #[cfg(not(target_arch = "wasm32"))]
   let mut load_obj_clicked = false;
@@ -1171,7 +1177,19 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
       ui.separator();
 
       if let Some((solve_time, duration)) = model.trajectory {
-        ui.monospace(format!("t = {solve_time:.3} / {duration:.3}"));
+        // A draggable playhead over the solve-time interval: while playing it
+        // tracks the clock (the slider reads the live position), and a drag
+        // overrides it to scrub. The value is taken as owned so binding the
+        // slider to it never writes back into the model snapshot.
+        let mut t = solve_time;
+        let response = ui.add(
+          egui::Slider::new(&mut t, 0.0..=duration.max(f64::EPSILON))
+            .text("t")
+            .fixed_decimals(3),
+        );
+        if response.dragged() || response.changed() {
+          scrub_time = Some(t);
+        }
       } else {
         match omega {
           Some(omega) if omega > 1e-9 => {
@@ -1226,6 +1244,7 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
     orthographic,
     reset_camera,
     camera_view,
+    scrub_time,
     playing,
     #[cfg(not(target_arch = "wasm32"))]
     load_obj_clicked,

--- a/crates/studio/src/ui.rs
+++ b/crates/studio/src/ui.rs
@@ -957,8 +957,14 @@ pub(crate) fn panel(ui: &mut egui::Ui, model: &PanelModel) -> PanelResponse {
 
         section(ui, "Presets", |ui| {
           for (i, preset) in model.presets.iter().enumerate() {
+            // A preset is lit when the platform is standing exactly on the
+            // point it names -- its mesh and study both current -- so the
+            // browser shows where the reader is, not just where they can go.
+            // Editing an axis away from a preset unlights it; returning relights
+            // it, with no state beyond the two axes themselves.
+            let active = preset.mesh == model.mesh_source && preset.study == model.study;
             if ui
-              .selectable_label(false, preset.name)
+              .selectable_label(active, preset.name)
               .on_hover_text(preset.description)
               .clicked()
             {

--- a/crates/studio/src/web.rs
+++ b/crates/studio/src/web.rs
@@ -68,6 +68,35 @@ pub(crate) fn take_ready_state() -> Option<State> {
   READY_STATE.with(|slot| slot.borrow_mut().take())
 }
 
+/// The `localStorage` key the dismissed-welcome flag is stored under. The web
+/// half of [`crate::welcome`]'s persistence: the browser has no filesystem for
+/// a marker file, so the one-time greeting is remembered here instead. All the
+/// `localStorage` access is confined to this module, the same discipline the
+/// rest of the web glue keeps.
+const WELCOME_KEY: &str = "formoniq-studio.welcome_seen";
+
+/// The browser's `localStorage`, if the document exposes it (a private-mode or
+/// sandboxed context may not). `None` is treated by the callers as "not stored",
+/// so the greeting simply shows each launch there rather than failing.
+fn local_storage() -> Option<web_sys::Storage> {
+  web_sys::window().and_then(|w| w.local_storage().ok().flatten())
+}
+
+/// Whether the reader has dismissed the welcome before, read from
+/// `localStorage`. False (show it) when the store is unavailable or the key is
+/// unset.
+pub(crate) fn welcome_seen() -> bool {
+  local_storage().is_some_and(|store| store.get_item(WELCOME_KEY).ok().flatten().is_some())
+}
+
+/// Records that the welcome was dismissed. Best-effort: a store that rejects the
+/// write leaves the greeting to reappear next launch rather than erroring.
+pub(crate) fn mark_welcome_seen() {
+  if let Some(store) = local_storage() {
+    let _ = store.set_item(WELCOME_KEY, "1");
+  }
+}
+
 /// Appends the winit-created `<canvas>` to the document body and sizes it to
 /// fill the viewport. winit builds the canvas but leaves attaching it to the
 /// page to the embedder.

--- a/crates/studio/src/welcome.rs
+++ b/crates/studio/src/welcome.rs
@@ -1,0 +1,74 @@
+//! The one-time welcome shown on a reader's first launch, and the small bit of
+//! persistence that keeps it to the first.
+//!
+//! The greeting differs by platform because the two viewers genuinely do: what
+//! a native reader can reach (local files, the keyboard fly) a browser one
+//! cannot, and the browser's own terms (WebGPU, the solve in a worker) are not
+//! the desktop's. The persistence is likewise split at the one real seam -- a
+//! marker file natively, `localStorage` on the web -- with the web half living
+//! in `web.rs`, so nothing browser-specific leaks out of it.
+
+/// The modal's title, shared across platforms.
+pub(crate) const TITLE: &str = "Welcome to formoniq-studio";
+
+/// The greeting body, in the reader's own platform's terms.
+pub(crate) fn message() -> &'static str {
+  #[cfg(not(target_arch = "wasm32"))]
+  {
+    "You are running the native viewer.\n\n\
+     • Pick a preset in the Browser on the left, or compose a mesh and a study yourself.\n\
+     • Orbit with the left mouse button, look with the right, pan with the middle; scroll to zoom, and fly with WASD.\n\
+     • Load your own OBJ meshes and export stills from the File menu.\n\n\
+     The full controls are under Help › Navigation."
+  }
+  #[cfg(target_arch = "wasm32")]
+  {
+    "You are running in the browser, on WebGPU. Studies solve in a background worker, so the view stays responsive while they run.\n\n\
+     • Pick a preset in the Browser on the left, or compose a mesh and a study yourself.\n\
+     • Drag to orbit and look, scroll or pinch to zoom; one finger looks, two fingers pan.\n\
+     • Local files and image export are native-only, so they are absent here.\n\n\
+     The full controls are under Help › Navigation."
+  }
+}
+
+/// Whether the welcome should be shown -- true until the reader has dismissed it
+/// once, remembered across launches per platform. A failure to read the marker
+/// errs toward showing it: greeting a returning reader once more is a smaller
+/// harm than hiding it from a new one.
+pub(crate) fn should_show() -> bool {
+  !seen()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn marker_path() -> Option<std::path::PathBuf> {
+  directories::ProjectDirs::from("", "", "formoniq-studio")
+    .map(|dirs| dirs.config_dir().join("welcome_seen"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn seen() -> bool {
+  marker_path().is_some_and(|path| path.exists())
+}
+
+/// Records that the welcome has been dismissed, so the next launch skips it.
+/// Best-effort: a write failure (an unwritable config dir) leaves the greeting
+/// to reappear next time rather than taking the viewer down for it.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn mark_seen() {
+  if let Some(path) = marker_path() {
+    if let Some(parent) = path.parent() {
+      let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, b"");
+  }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn seen() -> bool {
+  crate::web::welcome_seen()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn mark_seen() {
+  crate::web::mark_welcome_seen();
+}


### PR DESCRIPTION
Introduce a top menu bar (File, View, Help) as the conventional home for
commands that belong to neither object on screen: reading and writing files
(Load OBJ, Export PNG, native only), and how the shell is laid out and lit
(sidebar toggles, Orthographic, the Light ladder). These move out of the
inspector, which was carrying view-shell commands beside the object properties.

Make Study's variant parameters editable, closing the gap the model always
described but the UI never reached: the eigenmode count, the trajectory
sampling steps and final time now have sliders, beside the grade tabs. An edit
that drives a re-solve commits on release, not every frame the handle sweeps
(commit_slider), so the background solve fires once. The mesh refinement
sliders adopt the same commit-on-release.

Reorganize the inspector into Study / Modes / Mesh / Field sections mirroring
the crate's own seam, and wrap both sidebars in scroll areas.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016NX3H9iKnmnja138e9BEkm